### PR TITLE
Fix issues with lists

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -528,15 +528,24 @@ impl Application for Tasks {
                                 ));
                             }
                             DialogPage::Rename(name) => {
-                                let entity = self.nav_model.active();
-                                self.nav_model.text_set(entity, name.clone());
                                 if let Some(list) = self.nav_model.active_data_mut::<List>() {
+                                    let title = if let Some(icon) = list.icon() {
+                                        format!("{} {}", icon.clone(), &name)
+                                    } else {
+                                        name.clone()
+                                    };
                                     list.name.clone_from(&name);
+                                    let list = list.clone();
+                                    self.nav_model
+                                        .text_set(self.nav_model.active(), title.clone());
                                     let task = app::Task::perform(
                                         todo::update_list(list.clone(), self.service.clone()),
                                         |_| message::none(),
                                     );
                                     tasks.push(task);
+                                    tasks.push(self.update(Message::Content(
+                                        content::Message::List(Some(list)),
+                                    )));
                                 }
                             }
                             DialogPage::Delete => {
@@ -550,11 +559,15 @@ impl Application for Tasks {
                                 }
                                 if let Some(list) = self.nav_model.active_data_mut::<List>() {
                                     list.icon = Some(icon);
+                                    let list = list.clone();
                                     let task = app::Task::perform(
                                         todo::update_list(list.clone(), self.service.clone()),
                                         |_| message::none(),
                                     );
                                     tasks.push(task);
+                                    tasks.push(self.update(Message::Content(
+                                        content::Message::List(Some(list)),
+                                    )));
                                 }
                             }
                             DialogPage::Calendar(date) => {

--- a/src/content.rs
+++ b/src/content.rs
@@ -184,10 +184,18 @@ impl Content {
         let mut tasks = Vec::new();
         match message {
             Message::List(list) => {
-                self.list.clone_from(&list);
-                if let Some(list) = list {
-                    tasks.push(Task::GetTasks(list.id().clone()));
+                match (&self.list, &list) {
+                    (Some(current), Some(list)) => {
+                        if current.id != list.id {
+                            tasks.push(Task::GetTasks(list.id().clone()));
+                        }
+                    }
+                    (None, Some(list)) => {
+                        tasks.push(Task::GetTasks(list.id().clone()));
+                    }
+                    _ => {}
                 }
+                self.list.clone_from(&list);
             }
             Message::TitleUpdate(id, title) => {
                 if let Some(task) = self.tasks.get_mut(id) {


### PR DESCRIPTION
List actions now receive an optional entity depending on where the action was triggered, either the menu or the context menu, this allows the actions to be performed on the selected entity rather than the active one for the context menu.

- Renaming no longer removes the list icon.
- Renaming or setting an icon also updates the content view.

Closes #25 