### PR TITLE
Add spanish translation and code improvements

### DIFF
--- a/i18n/es-419/tasks.ftl
+++ b/i18n/es-419/tasks.ftl
@@ -1,0 +1,91 @@
+tasks = Tareas
+trash = Basura
+about = Acerca de
+
+# Content
+add-new-task = Añadir nueva tarea
+
+# Details
+title = Título
+details = Detalles
+favorite = Favorito
+priority = Prioridad
+due-date = Fecha de vencimiento
+reminder = Recordatorio
+notes = Notas
+
+# Empty
+no-tasks = No hay tareas
+no-tasks-suggestion = Intenta añadir una nueva tarea con el campo de texto de abajo
+no-list-selected = No hay lista seleccionada
+no-list-suggestion = Crea o selecciona una lista para comenzar
+
+sub-tasks = Subtareas
+add-sub-task = Añadir subtarea
+
+# New List Dialog
+create-list = Crear nueva lista de tareas
+
+# Rename List Dialog
+rename-list = Renombrar lista de tareas
+
+# Rename List Dialog
+delete-list = La lista seleccionada será eliminada
+delete-list-confirm = ¿Estas seguro de que deseas eliminar esta lista?
+
+# Icon Dialog
+icon = Establecer icono
+icon-select = Seleccionar un icono
+icon-select-body = Seleccionar un icono para la lista de tareas
+
+# Date Dialog
+select-date = Selecciona una fecha
+
+# Export Dialog
+export = Exportar
+
+# Dialogs
+cancel = Cancelar
+ok = Ok
+copy = Copiar
+confirm = Confirmar
+save = Guardar
+list-name = Nombre de la lista
+
+# Context Pages
+
+## Properties
+properties = Propiedades
+
+## Settings
+settings = Ajustes
+
+### Appearance
+appearance = Apariencia
+theme = Tema
+match-desktop = Igualar escritorio
+dark = Oscuro
+light = Claro
+
+# Menu
+
+## File
+file = Archivo
+new-window = Nueva ventana
+new-list = Nueva lista
+quit = Cerrar
+
+## Edit
+edit = Editar
+rename = Renombrar
+delete = Eliminar
+
+## View
+view = Ver
+menu-settings = Ajustes
+menu-about = Acerca de Tareas
+
+## About
+repository = Repositorio
+support = Soporte
+website = Sitio web

--- a/i18n/es-MX/tasks.ftl
+++ b/i18n/es-MX/tasks.ftl
@@ -1,0 +1,91 @@
+tasks = Tareas
+trash = Basura
+about = Acerca de
+
+# Content
+add-new-task = Añadir nueva tarea
+
+# Details
+title = Título
+details = Detalles
+favorite = Favorito
+priority = Prioridad
+due-date = Fecha de vencimiento
+reminder = Recordatorio
+notes = Notas
+
+# Empty
+no-tasks = No hay tareas
+no-tasks-suggestion = Intenta añadir una nueva tarea con el campo de texto de abajo
+no-list-selected = No hay lista seleccionada
+no-list-suggestion = Crea o selecciona una lista para comenzar
+
+sub-tasks = Subtareas
+add-sub-task = Añadir subtarea
+
+# New List Dialog
+create-list = Crear nueva lista de tareas
+
+# Rename List Dialog
+rename-list = Renombrar lista de tareas
+
+# Rename List Dialog
+delete-list = La lista seleccionada será eliminada
+delete-list-confirm = ¿Estas seguro de que deseas eliminar esta lista?
+
+# Icon Dialog
+icon = Establecer icono
+icon-select = Seleccionar un icono
+icon-select-body = Seleccionar un icono para la lista de tareas
+
+# Date Dialog
+select-date = Selecciona una fecha
+
+# Export Dialog
+export = Exportar
+
+# Dialogs
+cancel = Cancelar
+ok = Ok
+copy = Copiar
+confirm = Confirmar
+save = Guardar
+list-name = Nombre de la lista
+
+# Context Pages
+
+## Properties
+properties = Propiedades
+
+## Settings
+settings = Ajustes
+
+### Appearance
+appearance = Apariencia
+theme = Tema
+match-desktop = Igualar escritorio
+dark = Oscuro
+light = Claro
+
+# Menu
+
+## File
+file = Archivo
+new-window = Nueva ventana
+new-list = Nueva lista
+quit = Cerrar
+
+## Edit
+edit = Editar
+rename = Renombrar
+delete = Eliminar
+
+## View
+view = Ver
+menu-settings = Ajustes
+menu-about = Acerca de Tareas
+
+## About
+repository = Repositorio
+support = Soporte
+website = Sitio web

--- a/i18n/es/tasks.ftl
+++ b/i18n/es/tasks.ftl
@@ -1,0 +1,91 @@
+tasks = Tareas
+trash = Basura
+about = Acerca de
+
+# Content
+add-new-task = Añadir nueva tarea
+
+# Details
+title = Título
+details = Detalles
+favorite = Favorito
+priority = Prioridad
+due-date = Fecha de vencimiento
+reminder = Recordatorio
+notes = Notas
+
+# Empty
+no-tasks = No hay tareas
+no-tasks-suggestion = Intenta añadir una nueva tarea con el campo de texto de abajo
+no-list-selected = No hay lista seleccionada
+no-list-suggestion = Crea o selecciona una lista para comenzar
+
+sub-tasks = Subtareas
+add-sub-task = Añadir subtarea
+
+# New List Dialog
+create-list = Crear nueva lista de tareas
+
+# Rename List Dialog
+rename-list = Renombrar lista de tareas
+
+# Rename List Dialog
+delete-list = La lista seleccionada será eliminada
+delete-list-confirm = ¿Estas seguro de que deseas eliminar esta lista?
+
+# Icon Dialog
+icon = Establecer icono
+icon-select = Seleccionar un icono
+icon-select-body = Seleccionar un icono para la lista de tareas
+
+# Date Dialog
+select-date = Selecciona una fecha
+
+# Export Dialog
+export = Exportar
+
+# Dialogs
+cancel = Cancelar
+ok = Ok
+copy = Copiar
+confirm = Confirmar
+save = Guardar
+list-name = Nombre de la lista
+
+# Context Pages
+
+## Properties
+properties = Propiedades
+
+## Settings
+settings = Ajustes
+
+### Appearance
+appearance = Apariencia
+theme = Tema
+match-desktop = Igualar escritorio
+dark = Oscuro
+light = Claro
+
+# Menu
+
+## File
+file = Archivo
+new-window = Nueva ventana
+new-list = Nueva lista
+quit = Cerrar
+
+## Edit
+edit = Editar
+rename = Renombrar
+delete = Eliminar
+
+## View
+view = Ver
+menu-settings = Ajustes
+menu-about = Acerca de Tareas
+
+## About
+repository = Repositorio
+support = Soporte
+website = Sitio web

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -88,7 +88,7 @@ pub fn menu_bar<'a>(key_binds: &HashMap<KeyBind, Action>) -> Element<'a, Message
         ),
     ])
     .item_height(ItemHeight::Dynamic(40))
-    .item_width(ItemWidth::Uniform(240))
+    .item_width(ItemWidth::Uniform(260))
     .spacing(4.0)
     .into()
 }

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -9,18 +9,18 @@ use super::config::TasksConfig;
 use super::localize::localize;
 use super::Tasks;
 
-pub fn settings() -> Settings {
+pub fn init() {
     localize();
     icons();
     log();
     migrate(&["com.system76.CosmicTasks", "dev.edfloreshz.Orderly"]);
+}
 
-    let config = TasksConfig::config();
-
+pub fn settings() -> Settings {
     Settings::default()
         .antialiasing(true)
         .client_decorations(true)
-        .theme(config.app_theme.theme())
+        .theme(TasksConfig::config().app_theme.theme())
         .size_limits(Limits::NONE.min_width(350.0).min_height(180.0))
         .size(Size::new(700.0, 750.0))
         .debug(false)

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,10 @@ mod core;
 mod details;
 mod todo;
 
-use app::settings::{flags, settings};
+use app::settings;
 pub use core::Error;
 
 pub fn main() -> cosmic::iced::Result {
-    cosmic::app::run::<app::Tasks>(settings(), flags())
+    settings::init();
+    cosmic::app::run::<app::Tasks>(settings::settings(), settings::flags())
 }


### PR DESCRIPTION
This pull request includes several changes to add localization support for Spanish and its regional variations, as well as some modifications to the application settings and menu bar. The most important changes are summarized below:

Localization support:

* Added Spanish (Spain) localization strings in `i18n/es/tasks.ftl`.
* Added Spanish (Mexico) localization strings in `i18n/es-MX/tasks.ftl`.
* Added Spanish (Latin America) localization strings in `i18n/es-419/tasks.ftl`.

Application settings and menu bar:

* Modified `item_width` in the `menu_bar` function in `src/app/menu.rs` to increase the width from 240 to 260.
* Refactored the `settings` function in `src/app/settings.rs` to separate the initialization logic into a new `init` function.
* Updated the `main` function in `src/main.rs` to call the new `init` function before running the application.