### PR TITLE
feat: add hide completed tasks button

### DIFF
--- a/i18n/en/tasks.ftl
+++ b/i18n/en/tasks.ftl
@@ -84,6 +84,7 @@ delete = Delete
 view = View
 menu-settings = Settings...
 menu-about = About Tasks...
+hide-completed = Hide completed
 
 ## About
 repository = Repository

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -19,6 +19,7 @@ pub enum Action {
     DeleteList,
     RenameList,
     Icon,
+    ToggleHideCompleted(bool),
 }
 
 #[derive(Debug, Clone)]
@@ -34,6 +35,7 @@ pub enum ApplicationAction {
     Dialog(DialogAction),
     ToggleContextDrawer,
     ToggleContextPage(ContextPage),
+    ToggleHideCompleted(bool),
 }
 
 #[derive(Debug, Clone)]
@@ -69,6 +71,9 @@ impl MenuAction for Action {
             Action::DeleteList => Message::Application(ApplicationAction::Dialog(
                 DialogAction::Open(DialogPage::Delete(None)),
             )),
+            Action::ToggleHideCompleted(value) => {
+                Message::Application(ApplicationAction::ToggleHideCompleted(*value))
+            }
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -195,7 +195,7 @@ impl Application for Tasks {
     }
 
     fn header_start(&self) -> Vec<Element<Self::Message>> {
-        vec![menu::menu_bar(&self.key_binds)]
+        vec![menu::menu_bar(&self.key_binds, &self.config)]
     }
 
     fn nav_context_menu(
@@ -445,6 +445,13 @@ impl Application for Tasks {
                 ApplicationAction::AppTheme(theme) => {
                     if let Some(handler) = &self.config_handler {
                         if let Err(err) = self.config.set_app_theme(&handler, theme.into()) {
+                            tracing::error!("{err}")
+                        }
+                    }
+                }
+                ApplicationAction::ToggleHideCompleted(value) => {
+                    if let Some(handler) = &self.config_handler {
+                        if let Err(err) = self.config.set_hide_completed(&handler, value) {
                             tracing::error!("{err}")
                         }
                     }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -11,6 +11,7 @@ pub const CONFIG_VERSION: u64 = 1;
 #[derive(Clone, Default, Debug, Eq, PartialEq, Deserialize, Serialize, CosmicConfigEntry)]
 pub struct TasksConfig {
     pub app_theme: AppTheme,
+    pub hide_completed: bool,
 }
 
 impl TasksConfig {

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -13,7 +13,12 @@ use crate::{
     fl,
 };
 
-pub fn menu_bar<'a>(key_binds: &HashMap<KeyBind, Action>) -> Element<'a, Message> {
+use super::config::TasksConfig;
+
+pub fn menu_bar<'a>(
+    key_binds: &HashMap<KeyBind, Action>,
+    config: &TasksConfig,
+) -> Element<'a, Message> {
     MenuBar::new(vec![
         Tree::with_children(
             root(fl!("file")),
@@ -74,6 +79,13 @@ pub fn menu_bar<'a>(key_binds: &HashMap<KeyBind, Action>) -> Element<'a, Message
                         fl!("menu-settings"),
                         Some(icons::get_handle("settings-symbolic", 14)),
                         Action::Settings,
+                    ),
+                    Item::Divider,
+                    Item::CheckBox(
+                        fl!("hide-completed"),
+                        None,
+                        config.hide_completed,
+                        Action::ToggleHideCompleted(!config.hide_completed),
                     ),
                     Item::Divider,
                     Item::Button(

--- a/src/content.rs
+++ b/src/content.rs
@@ -30,7 +30,7 @@ pub enum Message {
     Delete(DefaultKey),
     EditMode(DefaultKey, bool),
     Export(Vec<models::Task>),
-    ToggleComplete,
+    ToggleHideCompleted,
     Input(String),
     List(Option<List>),
     Select(models::Task),
@@ -67,7 +67,7 @@ impl Content {
         let export_button = widget::button::icon(icons::get_handle("share-symbolic", 18))
             .class(cosmic::style::Button::Suggested)
             .padding(spacing.space_xxs)
-            .on_press(Message::ToggleComplete);
+            .on_press(Message::ToggleHideCompleted);
 
         let hide_complete_button = widget::button::icon(icons::get_handle("share-symbolic", 18))
             .class(cosmic::style::Button::Suggested)
@@ -282,7 +282,7 @@ impl Content {
             Message::Export(exported_tasks) => {
                 tasks.push(Task::Export(exported_tasks));
             }
-            Message::ToggleComplete => self.hide_complete = !self.hide_complete,
+            Message::ToggleHideCompleted => self.hide_complete = !self.hide_complete,
         }
         tasks
     }


### PR DESCRIPTION
Hello, 
This PR adds toggle button to hide completed tasks. I added button next to the export button. 

TODO:
[ ] Change icon
[ ] Use config state as fallback