### PR TITLE
Fix text input focus behavior

### DIFF
--- a/i18n/en/tasks.ftl
+++ b/i18n/en/tasks.ftl
@@ -39,6 +39,7 @@ delete-list-confirm = Are you sure you want to delete this list?
 icon = Set icon
 icon-select = Select an icon
 icon-select-body = Choose an icon for the list
+search-icons = Search icons...
 
 # Date Dialog
 select-date = Select a date

--- a/src/app.rs
+++ b/src/app.rs
@@ -205,15 +205,10 @@ impl Tasks {
                                 self.nav_model.active_data_mut::<List>()
                             };
                             if let Some(list) = data {
-                                let title = if let Some(icon) = &list.icon {
-                                    format!("{} {}", icon.clone(), &name)
-                                } else {
-                                    name.clone()
-                                };
-                                list.name.clone_from(&name);
+                                list.name.clone_from(&name.clone());
                                 let list = list.clone();
                                 self.nav_model
-                                    .text_set(self.nav_model.active(), title.clone());
+                                    .text_set(self.nav_model.active(), name.clone());
                                 if let Err(err) = self.storage.update_list(&list) {
                                     tracing::error!("Error updating list: {err}");
                                 }

--- a/src/content.rs
+++ b/src/content.rs
@@ -450,6 +450,7 @@ impl Content {
         let spacing = theme::active().cosmic().spacing;
         row(vec![
             widget::text_input(fl!("add-new-task"), &self.input)
+                .id(widget::Id::new("new-task-input"))
                 .on_input(Message::TaskTitleInput)
                 .on_submit(|_| Message::TaskAdd)
                 .width(Length::Fill)
@@ -606,6 +607,7 @@ impl Content {
                     match self.storage.update_task(task) {
                         Ok(_) => {
                             self.task_editing.insert(id, false);
+                            tasks.push(Output::Focus(widget::Id::new("new-task-input")));
                         }
                         Err(error) => tracing::error!("Failed to update task: {:?}", error),
                     }
@@ -680,6 +682,7 @@ impl Content {
                     match self.storage.update_task(task) {
                         Ok(_) => {
                             self.sub_task_editing.insert(id, false);
+                            tasks.push(Output::Focus(widget::Id::new("new-task-input")));
                         }
                         Err(error) => tracing::error!("Failed to update sub-task: {:?}", error),
                     }

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -114,8 +114,9 @@ impl DialogPage {
                     })
                     .collect();
 
-                let search_input =
-                    widget::text_input("Search icons...", search.as_str()).on_input({
+                let search_input = widget::text_input("Search icons...", search.as_str())
+                    .id(text_input_id.clone())
+                    .on_input({
                         let entity = *entity;
                         let icon = icon.clone();
                         move |s| {

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -114,7 +114,7 @@ impl DialogPage {
                     })
                     .collect();
 
-                let search_input = widget::text_input("Search icons...", search.as_str())
+                let search_input = widget::text_input(fl!("search-icons"), search.as_str())
                     .id(text_input_id.clone())
                     .on_input({
                         let entity = *entity;


### PR DESCRIPTION
This PR brings improvements to text input focus behavior.

- Fixed an issue where renaming lists would be formatted incorrectly.
- Added a widget id to new task input.
- Fixed tasks not losing focus, focus is now directed to add new task.
- Fixed icon search bar not receiving the focus when shown

Fixes #66