### PR TITLE
Fix key bindings to avoid text editing issues

### DIFF
--- a/src/app/key_bind.rs
+++ b/src/app/key_bind.rs
@@ -24,9 +24,9 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     }
 
     bind!([Ctrl], Key::Character("n".into()), NewList);
-    bind!([], Key::Named(Named::Delete), DeleteList);
+    bind!([Ctrl], Key::Named(Named::Delete), DeleteList);
     bind!([Ctrl], Key::Character("r".into()), RenameList);
-    bind!([Shift], Key::Character("I".into()), Icon);
+    bind!([Ctrl], Key::Character("I".into()), Icon);
     bind!([Ctrl], Key::Character("w".into()), WindowClose);
     bind!([Ctrl, Shift], Key::Character("n".into()), WindowNew);
     bind!([Ctrl], Key::Character(",".into()), Settings);


### PR DESCRIPTION
This pull request updates key bindings to standardize the use of the `Ctrl` modifier and avoid text editing issues.

Key binding updates:

* Changed the `DeleteList` action to use `[Ctrl]` instead of no modifier.
* Updated the `Icon` action to use `[Ctrl]` instead of `[Shift]`.

New key binds:
- Delete  `Ctrl + Del`
- Icon `Ctrl + I`

Fixes #46