### PR TITLE
feat: focus specific inputs for better UX

### DIFF
--- a/src/app/dialogs/update.rs
+++ b/src/app/dialogs/update.rs
@@ -6,7 +6,6 @@ use crate::{
     app::{
         core::{AppModel, Message},
         navigation::TasksAction,
-        ui::ApplicationAction,
     },
     model::List,
     pages::{content, details},
@@ -32,9 +31,7 @@ impl AppModel {
                     }
                     page => self.dialog_pages.push_back(page),
                 }
-                return cosmic::task::message(Message::Application(ApplicationAction::Focus(
-                    self.dialog_text_input.clone(),
-                )));
+                return cosmic::widget::text_input::focus(self.dialog_text_input.clone());
             }
             DialogAction::Update(dialog_page) => {
                 self.dialog_pages[0] = dialog_page;

--- a/src/app/navigation/actions.rs
+++ b/src/app/navigation/actions.rs
@@ -7,6 +7,7 @@ pub enum TasksAction {
     AddList(List),
     DeleteList(Option<segmented_button::Entity>),
     FetchLists,
+    NavSelect(segmented_button::Entity),
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/src/app/navigation/update.rs
+++ b/src/app/navigation/update.rs
@@ -14,6 +14,9 @@ use super::NavMenuAction;
 impl AppModel {
     pub fn update_tasks(&mut self, action: TasksAction) -> app::Task<Message> {
         match action {
+            TasksAction::NavSelect(entity) => {
+                return self.on_nav_select(entity);
+            }
             TasksAction::FetchLists => match self.store.lists().load_all() {
                 Ok(lists) => {
                     return self.update(Message::Tasks(TasksAction::PopulateLists(lists)));
@@ -30,7 +33,7 @@ impl AppModel {
                     return app::Task::none();
                 };
                 self.nav.activate(entity);
-                return self.on_nav_select(entity);
+                return cosmic::task::message(Message::Tasks(TasksAction::NavSelect(entity)));
             }
             TasksAction::AddList(list) => {
                 self.create_nav_item(&list);

--- a/src/app/ui/actions.rs
+++ b/src/app/ui/actions.rs
@@ -1,6 +1,6 @@
 use cosmic::{
     iced::keyboard::{Key, Modifiers},
-    widget::{self, menu::Action},
+    widget::menu::Action,
 };
 
 use crate::app::core::{ContextPage, Message};
@@ -27,7 +27,6 @@ pub enum ApplicationAction {
     Key(Modifiers, Key),
     Modifiers(Modifiers),
     AppTheme(usize),
-    Focus(widget::Id),
 }
 
 impl Action for MenuAction {

--- a/src/app/ui/update.rs
+++ b/src/app/ui/update.rs
@@ -31,9 +31,6 @@ impl AppModel {
             ApplicationAction::Modifiers(modifiers) => {
                 self.modifiers = modifiers;
             }
-            ApplicationAction::Focus(id) => {
-                return cosmic::task::message(Message::Application(ApplicationAction::Focus(id)));
-            }
         }
 
         app::Task::none()

--- a/src/pages/content.rs
+++ b/src/pages/content.rs
@@ -162,7 +162,9 @@ impl Content {
         match message {
             Message::ToggleSearchBar => {
                 self.search_bar_visible = !self.search_bar_visible;
-                if !self.search_bar_visible {
+                if self.search_bar_visible {
+                    output = Some(Output::Focus(widget::Id::new("search-tasks-input")));
+                } else {
                     self.search_query.clear();
                 }
             }
@@ -208,6 +210,9 @@ impl Content {
                     _ => {}
                 }
                 self.selected_list.clone_from(&list);
+                if list.is_some() {
+                    return Some(Output::Focus(widget::Id::new("new-task-input")));
+                }
             }
             Message::SetConfig(config) => {
                 self.config = config;
@@ -532,7 +537,9 @@ impl Content {
     /// Creates the search input field
     fn create_search_input<'a>(&'a self, spacing: &Spacing) -> Element<'a, Message> {
         widget::text_input(fl!("search-tasks"), &self.search_query)
+            .id(widget::Id::new("search-tasks-input"))
             .on_input(Message::SearchQueryChanged)
+            .on_unfocus(Message::ToggleSearchBar)
             .width(Length::Fill)
             .padding([spacing.space_xxs, spacing.space_xxs])
             .into()
@@ -566,7 +573,7 @@ impl Content {
         widget::button::icon(widget::icon::from_name("edit-find-symbolic").size(18))
             .selected(self.search_bar_visible)
             .padding(spacing.space_xxs)
-            .on_press(Message::ToggleSearchBar)
+            .on_press_maybe((!self.search_bar_visible).then_some(Message::ToggleSearchBar))
             .into()
     }
 


### PR DESCRIPTION
This pull request enhances the search and task input focus logic for a better user experience.

- New task input is now focused on app start and when selecting or creating a list.
- Dialog inputs are selected when creating or renaming a list.
- Search input is selected when opened, it also handles discard events. 

Closes #93 