### PR TITLE
feat: add Trash page and trash management

### DIFF
--- a/i18n/en/tasks.ftl
+++ b/i18n/en/tasks.ftl
@@ -1,5 +1,15 @@
 tasks = Tasks
 trash = Trash
+empty-trash = Empty trash
+no-trash = Trash is empty
+no-trash-suggestion = Deleted tasks will appear here
+restore = Restore
+restore-all = Restore all
+delete-permanently = Delete permanently
+deleted-from = Deleted from "{ $list }"
+deleted-at = Deleted { $date }
+unknown-list = Unknown list
+trash-emptied = Trash emptied
 about = About
 
 # Content
@@ -26,6 +36,7 @@ no-list-suggestion = Create or select a new list to get started
 
 sub-tasks = Sub-tasks
 add-sub-task = Add sub-task
+move-to-trash = Move to trash
 
 # New List Dialog
 create-list = Create a new list

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,7 +20,7 @@ use crate::{
     config::AppConfig,
     fl,
     model::List,
-    pages::{content, details},
+    pages::{content, details, trash},
 };
 
 impl Application for AppModel {
@@ -80,6 +80,9 @@ impl Application for AppModel {
         &self,
         id: widget::nav_bar::Id,
     ) -> Option<Vec<widget::menu::Tree<cosmic::Action<Self::Message>>>> {
+        if self.nav.data::<crate::model::TrashMarker>(id).is_some() {
+            return navigation::trash_context_menu();
+        }
         navigation::nav_context_menu(id)
     }
 
@@ -100,6 +103,17 @@ impl Application for AppModel {
     fn on_nav_select(&mut self, entity: Entity) -> app::Task<Self::Message> {
         let mut tasks = vec![];
         self.nav.activate(entity);
+
+        // Check if trash was selected
+        if self.nav.data::<crate::model::TrashMarker>(entity).is_some() {
+            // Clear the content selection so that switching back to any list
+            // (including the same one) always triggers a fresh task reload.
+            return app::Task::batch(vec![
+                self.update(Message::Content(content::Message::SetList(None))),
+                self.update(Message::Trash(trash::Message::Load)),
+            ]);
+        }
+
         let location_opt = self.nav.data::<List>(entity);
 
         if let Some(list) = location_opt {
@@ -136,11 +150,11 @@ impl Application for AppModel {
             }),
         ];
 
-        // Tick the deletion countdown once per second while a task is pending.
-        if self.content.has_pending_deletion() {
+        // Tick the trash deletion countdown once per second while a task is pending.
+        if self.trash.has_pending_deletion() {
             subscriptions.push(
                 cosmic::iced::time::every(std::time::Duration::from_secs(1))
-                    .map(|_| Message::Content(content::Message::TaskDeletionTick)),
+                    .map(|_| Message::Trash(trash::Message::TaskDeletionTick)),
             );
         }
 
@@ -239,6 +253,9 @@ impl Application for AppModel {
                     }
                 }
             }
+            Message::Trash(msg) => {
+                self.trash.update(msg);
+            }
             Message::Tasks(action) => {
                 return self.update_tasks(action);
             }
@@ -271,6 +288,14 @@ impl Application for AppModel {
     }
 
     fn view(&self) -> Element<'_, Self::Message> {
-        self.content.view().map(Message::Content)
+        if self
+            .nav
+            .active_data::<crate::model::TrashMarker>()
+            .is_some()
+        {
+            self.trash.view().map(Message::Trash)
+        } else {
+            self.content.view().map(Message::Content)
+        }
     }
 }

--- a/src/app/core/init.rs
+++ b/src/app/core/init.rs
@@ -13,7 +13,7 @@ use cosmic::{
 use crate::{
     app::{navigation::TasksAction, ui::MenuAction},
     fl,
-    pages::{content::Content, details::Details},
+    pages::{content::Content, details::Details, trash::Trash},
 };
 
 use super::{context::ContextPage, flags::Flags, message::Message, model::AppModel};
@@ -34,10 +34,12 @@ impl AppModel {
             config: flags.config.clone(),
             store: flags.store.clone(),
             content: Content::new(flags.store.clone(), flags.config),
-            details: Details::new(flags.store),
+            details: Details::new(flags.store.clone()),
+            trash: Trash::new(flags.store),
             modifiers: Modifiers::empty(),
             dialog_pages: VecDeque::new(),
             dialog_text_input: widget::Id::unique(),
+            trash_entity: widget::segmented_button::Entity::default(),
         };
 
         let mut tasks = vec![cosmic::task::message(Message::Tasks(
@@ -49,6 +51,17 @@ impl AppModel {
         }
 
         app.core.nav_bar_toggle_condensed();
+
+        // Insert the trash nav item and remember its entity so we can always
+        // reposition it to the bottom after new lists are added.
+        let trash_icon = widget::icon::from_name("user-trash-full-symbolic").size(16);
+        app.trash_entity = app
+            .nav
+            .insert()
+            .text(fl!("trash"))
+            .icon(trash_icon)
+            .data(crate::model::TrashMarker)
+            .id();
 
         (app, app::Task::batch(tasks))
     }

--- a/src/app/core/message.rs
+++ b/src/app/core/message.rs
@@ -5,7 +5,7 @@ use crate::{
         ui::{ApplicationAction, MenuAction},
     },
     config::AppConfig,
-    pages::{content, details},
+    pages::{content, details, trash},
 };
 
 use super::ContextPage;
@@ -23,4 +23,5 @@ pub enum Message {
     ToggleContextPage(ContextPage),
     Open(String),
     UpdateConfig(AppConfig),
+    Trash(trash::Message),
 }

--- a/src/app/core/model.rs
+++ b/src/app/core/model.rs
@@ -10,7 +10,7 @@ use cosmic::{
 use crate::{
     app::{dialogs::DialogPage, ui::MenuAction},
     config,
-    pages::{content::Content, details::Details},
+    pages::{content::Content, details::Details, trash::Trash},
     services::store::Store,
 };
 
@@ -45,4 +45,8 @@ pub struct AppModel {
     pub(crate) content: Content,
     /// The details view for tasks.
     pub(crate) details: Details,
+    /// The trash page.
+    pub(crate) trash: Trash,
+    /// The nav bar entity for the trash item (kept so we can always reposition it last).
+    pub(crate) trash_entity: nav_bar::Id,
 }

--- a/src/app/navigation/actions.rs
+++ b/src/app/navigation/actions.rs
@@ -16,6 +16,8 @@ pub enum NavMenuAction {
     SetIcon(segmented_button::Entity),
     Export(segmented_button::Entity),
     Delete(segmented_button::Entity),
+    TrashEmptyAll,
+    TrashRestoreAll,
 }
 
 impl Action for NavMenuAction {

--- a/src/app/navigation/helpers.rs
+++ b/src/app/navigation/helpers.rs
@@ -3,7 +3,10 @@ use cosmic::widget::{
     segmented_button::{EntityMut, SingleSelect},
 };
 
-use crate::{app::{core::AppModel, ui::Markdown}, model::List};
+use crate::{
+    app::{core::AppModel, ui::Markdown},
+    model::List,
+};
 
 impl AppModel {
     pub fn create_nav_item(&mut self, list: &List) -> EntityMut<'_, SingleSelect> {
@@ -14,6 +17,19 @@ impl AppModel {
             .text(list.name.clone())
             .icon(icon)
             .data(list.clone())
+    }
+
+    /// Pin the trash entity to position 0 and place a divider below it
+    /// (i.e. divider_above on the item at position 1) so it is visually
+    /// separated from the list items beneath it.
+    pub fn reposition_trash(&mut self) {
+        self.nav.position_set(self.trash_entity, 0);
+        // Sweep all entities: only the item immediately after trash (index 1)
+        // gets a divider_above so the separator appears between trash and lists.
+        let entities: Vec<_> = self.nav.iter().collect();
+        for (i, entity) in entities.iter().enumerate() {
+            self.nav.divider_above_set(*entity, i == 1);
+        }
     }
 
     pub fn export_list(list: &List, tasks: &[crate::model::Task]) -> String {

--- a/src/app/navigation/menu.rs
+++ b/src/app/navigation/menu.rs
@@ -47,3 +47,29 @@ pub fn nav_context_menu(
         ],
     ))
 }
+
+pub fn trash_context_menu() -> Option<Vec<widget::menu::Tree<cosmic::Action<Message>>>> {
+    Some(cosmic::widget::menu::items(
+        &HashMap::new(),
+        vec![
+            cosmic::widget::menu::Item::Button(
+                fl!("restore-all"),
+                Some(
+                    widget::icon::from_name("edit-undo-symbolic")
+                        .size(14)
+                        .handle(),
+                ),
+                NavMenuAction::TrashRestoreAll,
+            ),
+            cosmic::widget::menu::Item::Button(
+                fl!("empty-trash"),
+                Some(
+                    widget::icon::from_name("user-trash-full-symbolic")
+                        .size(14)
+                        .handle(),
+                ),
+                NavMenuAction::TrashEmptyAll,
+            ),
+        ],
+    ))
+}

--- a/src/app/navigation/mod.rs
+++ b/src/app/navigation/mod.rs
@@ -4,4 +4,4 @@ pub mod menu;
 pub mod update;
 
 pub use actions::{NavMenuAction, TasksAction};
-pub use menu::nav_context_menu;
+pub use menu::{nav_context_menu, trash_context_menu};

--- a/src/app/navigation/update.rs
+++ b/src/app/navigation/update.rs
@@ -29,6 +29,7 @@ impl AppModel {
                 for list in lists {
                     self.create_nav_item(&list);
                 }
+                self.reposition_trash();
                 let Some(entity) = self.nav.iter().next() else {
                     return app::Task::none();
                 };
@@ -37,7 +38,19 @@ impl AppModel {
             }
             TasksAction::AddList(list) => {
                 self.create_nav_item(&list);
-                let Some(entity) = self.nav.iter().last() else {
+                self.reposition_trash();
+                // Select the newly added list, which is now second-to-last
+                // (last is always trash). Find it by its data.
+                let entity = self
+                    .nav
+                    .iter()
+                    .find(|e| {
+                        self.nav
+                            .data::<crate::model::List>(*e)
+                            .is_some_and(|l| l.id == list.id)
+                    })
+                    .or_else(|| self.nav.iter().last());
+                let Some(entity) = entity else {
                     return app::Task::none();
                 };
                 return self.on_nav_select(entity);
@@ -98,6 +111,16 @@ impl AppModel {
                 return cosmic::task::message(Message::Dialog(DialogAction::Open(
                     DialogPage::DeleteList(Some(entity)),
                 )));
+            }
+            NavMenuAction::TrashEmptyAll => {
+                return cosmic::task::message(Message::Trash(
+                    crate::pages::trash::Message::EmptyTrash,
+                ));
+            }
+            NavMenuAction::TrashRestoreAll => {
+                return cosmic::task::message(Message::Trash(
+                    crate::pages::trash::Message::RestoreAll,
+                ));
             }
         }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,4 +1,8 @@
 mod list;
 mod task;
 pub use list::List;
+pub use task::TrashedTask;
 pub use task::*;
+
+/// Zero-sized marker struct to tag the trash nav item.
+pub struct TrashMarker;

--- a/src/model/task.rs
+++ b/src/model/task.rs
@@ -129,6 +129,31 @@ pub enum Priority {
     High,
 }
 
+/// Represents a task that has been moved to the trash.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrashedTask {
+    /// The task that was trashed.
+    pub task: Task,
+    /// The list the task originally belonged to.
+    pub original_list_id: uuid::Uuid,
+    /// When the task was moved to trash.
+    pub deleted_at: jiff::Timestamp,
+}
+
+impl TrashedTask {
+    pub fn new(task: Task, original_list_id: uuid::Uuid) -> Self {
+        Self {
+            task,
+            original_list_id,
+            deleted_at: jiff::Timestamp::now(),
+        }
+    }
+    /// Returns `deleted_at` formatted in the system's local timezone.
+    pub fn deleted_at_local(&self) -> String {
+        Task::format_timestamp(&self.deleted_at)
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct Recurrence {
     pub monday: bool,

--- a/src/pages/content.rs
+++ b/src/pages/content.rs
@@ -33,16 +33,6 @@ enum EditState {
     Editing,
 }
 
-/// Holds the state of a task pending deletion so it can be undone.
-struct PendingDeletion {
-    /// The list that owns the task.
-    list_id: Uuid,
-    /// A full copy of the task, used to restore it on undo.
-    task: model::Task,
-    /// Seconds remaining before the deletion is committed to the store.
-    seconds_remaining: u8,
-}
-
 pub struct Content {
     selected_list: Option<List>,
     tasks: SlotMap<DefaultKey, model::Task>,
@@ -55,11 +45,6 @@ pub struct Content {
     add_task_input: String,
     search_query: String,
     sort_type: SortType,
-
-    /// A task that has been removed from the UI but not yet deleted from the
-    /// store.  The deletion is committed automatically after the countdown
-    /// reaches zero, or cancelled when the user presses "Undo".
-    pending_deletion: Option<PendingDeletion>,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -90,12 +75,8 @@ pub enum Message {
     SetConfig(config::AppConfig),
     RefreshTask(model::Task),
     Empty,
-    /// Request the deletion of a task; starts the undo countdown.
+    /// Request the deletion of a task; immediately moves the task to trash.
     OpenTaskDeletionDialog(DefaultKey),
-    /// Advance the deletion countdown by one second tick.
-    TaskDeletionTick,
-    /// Cancel the pending deletion and restore the task in the UI.
-    TaskDeletionUndo,
 
     ToggleSearchBar,
     SearchQueryChanged(String),
@@ -140,10 +121,6 @@ impl Content {
 
         let mut column = widget::column(vec![self.list_view(list)]);
 
-        if let Some(ref pending) = self.pending_deletion {
-            column = column.push(self.deletion_banner(pending, &spacing));
-        }
-
         column = column.push(self.new_task_view());
 
         column
@@ -180,12 +157,6 @@ impl Content {
                 self.populate_task_slotmap(tasks);
             }
             Message::SetList(list) => {
-                // Commit any pending deletion before switching to a different list.
-                if let Some(pending) = self.pending_deletion.take() {
-                    if let Err(err) = self.store.tasks(pending.list_id).delete(pending.task.id) {
-                        tracing::warn!("Failed to commit task deletion on list change: {err}");
-                    }
-                }
                 match (&self.selected_list, &list) {
                     (Some(current), Some(list)) => {
                         if current.id != list.id {
@@ -348,45 +319,20 @@ impl Content {
                     tracing::warn!("No list selected");
                     return None;
                 };
-
-                // If another task is already pending deletion, commit it now
-                // before starting a new countdown.
-                if let Some(existing) = self.pending_deletion.take() {
-                    if let Err(err) = self.store.tasks(existing.list_id).delete(existing.task.id) {
-                        tracing::error!("Error committing previous task deletion: {err}");
-                    }
-                }
+                let list_id = list.id;
 
                 if let Some(task) = self.tasks.remove(id) {
                     self.editing.remove(id);
                     self.inputs.remove(id);
-                    self.pending_deletion = Some(PendingDeletion {
-                        list_id: list.id,
-                        task,
-                        seconds_remaining: 5,
-                    });
-                }
-            }
-            Message::TaskDeletionTick => {
-                if let Some(pending) = &mut self.pending_deletion {
-                    if pending.seconds_remaining > 0 {
-                        pending.seconds_remaining -= 1;
+
+                    let trashed = crate::model::TrashedTask::new(task.clone(), list_id);
+                    if let Err(err) = self.store.trash().save(&trashed) {
+                        tracing::error!("Error moving task to trash: {err}");
                     }
-                    if pending.seconds_remaining == 0 {
-                        let pending = self.pending_deletion.take().unwrap();
-                        if let Err(err) = self.store.tasks(pending.list_id).delete(pending.task.id)
-                        {
-                            tracing::error!("Error committing task deletion: {err}");
-                        }
-                        output = Some(Output::TaskDeleted);
+                    if let Err(err) = self.store.tasks(list_id).delete(task.id) {
+                        tracing::error!("Error removing task from list after trashing: {err}");
                     }
-                }
-            }
-            Message::TaskDeletionUndo => {
-                if let Some(pending) = self.pending_deletion.take() {
-                    let new_key = self.tasks.insert(pending.task);
-                    self.inputs.insert(new_key, widget::Id::unique());
-                    self.editing.insert(new_key, EditState::Idle);
+                    output = Some(Output::TaskDeleted);
                 }
             }
             Message::TaskComplete(id, complete) => {
@@ -484,7 +430,6 @@ impl Content {
             search_bar_visible: false,
             search_query: String::new(),
             sort_type: SortType::DateAsc,
-            pending_deletion: None,
         }
     }
 
@@ -797,7 +742,7 @@ impl Content {
                         None,
                         TaskAction::AddSubTask(id),
                     ),
-                    widget::menu::Item::Button(fl!("delete"), None, TaskAction::Delete(id)),
+                    widget::menu::Item::Button(fl!("move-to-trash"), None, TaskAction::Delete(id)),
                 ],
             ),
         )])
@@ -887,38 +832,6 @@ impl Content {
             self.inputs.insert(task_id, widget::Id::unique());
             self.editing.insert(task_id, EditState::Idle);
         }
-    }
-
-    /// Returns `true` when a task is pending deletion (timer running).
-    pub fn has_pending_deletion(&self) -> bool {
-        self.pending_deletion.is_some()
-    }
-
-    /// Creates the sticky undo banner shown at the bottom of the content area
-    /// while a deletion is in progress.
-    fn deletion_banner<'a>(
-        &'a self,
-        pending: &'a PendingDeletion,
-        spacing: &Spacing,
-    ) -> Element<'a, Message> {
-        widget::container(
-            widget::row::with_capacity(3)
-                .push(
-                    widget::text(fl!("task-deleted", title = pending.task.title.as_str()))
-                        .width(Length::Fill),
-                )
-                .push(widget::text(fl!(
-                    "deletion-countdown",
-                    seconds = pending.seconds_remaining
-                )))
-                .push(widget::button::standard(fl!("undo")).on_press(Message::TaskDeletionUndo))
-                .align_y(Alignment::Center)
-                .spacing(spacing.space_s),
-        )
-        .class(cosmic::style::Container::Primary)
-        .padding(spacing.space_xxxs)
-        .width(Length::Fill)
-        .into()
     }
 
     /// Creates the view shown when no list is selected

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -1,2 +1,3 @@
 pub mod content;
 pub mod details;
+pub mod trash;

--- a/src/pages/trash.rs
+++ b/src/pages/trash.rs
@@ -1,0 +1,327 @@
+use cosmic::{
+    cosmic_theme::Spacing,
+    iced::{
+        alignment::{Horizontal, Vertical},
+        Alignment, Length,
+    },
+    theme, widget, Apply, Element,
+};
+use uuid::Uuid;
+
+use crate::{
+    fl,
+    model::{List, TrashedTask},
+    services::store::Store,
+};
+
+/// One or more trashed tasks pending permanent deletion (with undo window).
+struct PendingDeletion {
+    tasks: Vec<TrashedTask>,
+    seconds_remaining: u8,
+}
+
+pub struct Trash {
+    pub tasks: Vec<TrashedTask>,
+    pub lists: Vec<List>,
+    store: Store,
+    pending_deletion: Option<PendingDeletion>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    Load,
+    Loaded(Vec<TrashedTask>, Vec<List>),
+    RestoreTask(Uuid),
+    /// Begin the permanent-deletion countdown for a task.
+    DeleteTask(Uuid),
+    /// Advance the permanent-deletion countdown by one second.
+    TaskDeletionTick,
+    /// Cancel the pending permanent deletion (undo).
+    TaskDeletionUndo,
+    EmptyTrash,
+    /// Restore every task in the trash back to its original list.
+    RestoreAll,
+}
+
+impl Trash {
+    pub fn new(store: Store) -> Self {
+        Self {
+            tasks: Vec::new(),
+            lists: Vec::new(),
+            store,
+            pending_deletion: None,
+        }
+    }
+
+    /// Returns `true` when a permanent deletion countdown is active.
+    pub fn has_pending_deletion(&self) -> bool {
+        self.pending_deletion.is_some()
+    }
+
+    pub fn update(&mut self, message: Message) {
+        match message {
+            Message::Load => {
+                let tasks = self.store.trash().load_all().unwrap_or_else(|e| {
+                    tracing::error!("Failed to load trash: {e}");
+                    vec![]
+                });
+                let lists = self.store.lists().load_all().unwrap_or_else(|e| {
+                    tracing::error!("Failed to load lists for trash: {e}");
+                    vec![]
+                });
+                return self.update(Message::Loaded(tasks, lists));
+            }
+            Message::Loaded(tasks, lists) => {
+                self.tasks = tasks;
+                self.lists = lists;
+            }
+            Message::RestoreTask(task_id) => {
+                if let Some(pos) = self.tasks.iter().position(|t| t.task.id == task_id) {
+                    let trashed = self.tasks.remove(pos);
+                    if let Err(e) = self
+                        .store
+                        .tasks(trashed.original_list_id)
+                        .save(&trashed.task)
+                    {
+                        tracing::error!("Failed to restore task: {e}");
+                    } else if let Err(e) = self.store.trash().delete(task_id) {
+                        tracing::error!("Failed to remove task from trash after restore: {e}");
+                    }
+                }
+            }
+            Message::DeleteTask(task_id) => {
+                // Commit any previous pending permanent deletion first.
+                if let Some(existing) = self.pending_deletion.take() {
+                    for t in existing.tasks {
+                        if let Err(e) = self.store.trash().delete(t.task.id) {
+                            tracing::error!("Error committing previous permanent deletion: {e}");
+                        }
+                    }
+                }
+
+                if let Some(pos) = self.tasks.iter().position(|t| t.task.id == task_id) {
+                    let trashed = self.tasks.remove(pos);
+                    self.pending_deletion = Some(PendingDeletion {
+                        tasks: vec![trashed],
+                        seconds_remaining: 5,
+                    });
+                }
+            }
+            Message::TaskDeletionTick => {
+                if let Some(pending) = &mut self.pending_deletion {
+                    if pending.seconds_remaining > 0 {
+                        pending.seconds_remaining -= 1;
+                    }
+                    if pending.seconds_remaining == 0 {
+                        let pending = self.pending_deletion.take().unwrap();
+                        for t in pending.tasks {
+                            if let Err(e) = self.store.trash().delete(t.task.id) {
+                                tracing::error!("Error permanently deleting task from trash: {e}");
+                            }
+                        }
+                    }
+                }
+            }
+            Message::TaskDeletionUndo => {
+                if let Some(mut pending) = self.pending_deletion.take() {
+                    // Restore tasks in their original order (oldest first).
+                    pending.tasks.reverse();
+                    for t in pending.tasks {
+                        self.tasks.insert(0, t);
+                    }
+                }
+            }
+            Message::EmptyTrash => {
+                // Commit any previous pending permanent deletion first.
+                if let Some(existing) = self.pending_deletion.take() {
+                    for t in existing.tasks {
+                        if let Err(e) = self.store.trash().delete(t.task.id) {
+                            tracing::error!("Error committing previous permanent deletion: {e}");
+                        }
+                    }
+                }
+
+                if !self.tasks.is_empty() {
+                    let all_tasks = std::mem::take(&mut self.tasks);
+                    self.pending_deletion = Some(PendingDeletion {
+                        tasks: all_tasks,
+                        seconds_remaining: 5,
+                    });
+                }
+            }
+            Message::RestoreAll => {
+                // Commit any in-flight permanent deletion first.
+                self.pending_deletion.take();
+                let tasks = std::mem::take(&mut self.tasks);
+                for trashed in tasks {
+                    let task_id = trashed.task.id;
+                    if let Err(e) = self
+                        .store
+                        .tasks(trashed.original_list_id)
+                        .save(&trashed.task)
+                    {
+                        tracing::error!("Failed to restore task during RestoreAll: {e}");
+                    } else if let Err(e) = self.store.trash().delete(task_id) {
+                        tracing::error!("Failed to remove task from trash during RestoreAll: {e}");
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn view(&self) -> Element<'_, Message> {
+        let spacing = theme::active().cosmic().spacing;
+
+        if self.tasks.is_empty() && self.pending_deletion.is_none() {
+            return self.empty_view();
+        }
+
+        let header = self.header_view();
+
+        let task_rows: Vec<Element<'_, Message>> =
+            self.tasks.iter().map(|t| self.task_row(t)).collect();
+
+        let list = widget::column::with_children(task_rows).spacing(spacing.space_xxs);
+
+        let mut content = widget::column::with_capacity(3)
+            .push(header)
+            .push(widget::scrollable(list).height(Length::Fill))
+            .spacing(spacing.space_s)
+            .padding([spacing.space_xxs, spacing.space_xxxs]);
+
+        if let Some(ref pending) = self.pending_deletion {
+            content = content.push(self.deletion_banner(pending, &spacing));
+        }
+
+        widget::container(content)
+            .height(Length::Fill)
+            .width(Length::Fill)
+            .center_x(Length::Fill)
+            .max_width(800.)
+            .apply(widget::container)
+            .height(Length::Fill)
+            .width(Length::Fill)
+            .center(Length::Fill)
+            .into()
+    }
+
+    fn header_view(&self) -> Element<'_, Message> {
+        let spacing = theme::active().cosmic().spacing;
+
+        let icon = widget::icon::from_name("user-trash-full-symbolic").size(spacing.space_m);
+
+        let title = widget::text::body(fl!("trash"))
+            .size(24)
+            .width(Length::Fill);
+
+        // Disable the button while a countdown is already running.
+        let empty_button = widget::button::destructive(fl!("empty-trash")).on_press_maybe(
+            self.pending_deletion
+                .is_none()
+                .then_some(Message::EmptyTrash),
+        );
+
+        widget::row::with_capacity(3)
+            .align_y(Alignment::Center)
+            .spacing(spacing.space_s)
+            .padding([spacing.space_none, spacing.space_xxs])
+            .push(icon)
+            .push(title)
+            .push(empty_button)
+            .into()
+    }
+
+    fn task_row<'a>(&'a self, trashed: &'a TrashedTask) -> Element<'a, Message> {
+        let spacing = theme::active().cosmic().spacing;
+
+        let list_name = self
+            .lists
+            .iter()
+            .find(|l| l.id == trashed.original_list_id)
+            .map(|l| l.name.clone())
+            .unwrap_or_else(|| fl!("unknown-list"));
+
+        let title = widget::text::body(trashed.task.title.as_str()).width(Length::Fill);
+
+        let subtitle = widget::text(fl!("deleted-from", list = list_name.as_str()))
+            .size(12)
+            .width(Length::Fill);
+
+        let task_id = trashed.task.id;
+        let deleted_at = trashed.deleted_at_local();
+
+        let date = widget::text(fl!("deleted-at", date = deleted_at.as_str())).size(11);
+
+        let restore_button =
+            widget::button::standard(fl!("restore")).on_press(Message::RestoreTask(task_id));
+
+        let delete_button = widget::button::destructive(fl!("delete-permanently"))
+            .on_press(Message::DeleteTask(task_id));
+
+        let text_col = widget::column::with_capacity(3)
+            .push(title)
+            .push(subtitle)
+            .push(date)
+            .width(Length::Fill);
+
+        let row = widget::row::with_capacity(3)
+            .align_y(Alignment::Center)
+            .spacing(spacing.space_s)
+            .padding([spacing.space_xxxs, spacing.space_xs])
+            .push(text_col)
+            .push(restore_button)
+            .push(delete_button);
+
+        widget::container(row)
+            .class(cosmic::style::Container::ContextDrawer)
+            .width(Length::Fill)
+            .into()
+    }
+
+    fn deletion_banner<'a>(
+        &'a self,
+        pending: &'a PendingDeletion,
+        spacing: &Spacing,
+    ) -> Element<'a, Message> {
+        let label: String = if pending.tasks.len() == 1 {
+            fl!("task-deleted", title = pending.tasks[0].task.title.as_str())
+        } else {
+            fl!("trash-emptied")
+        };
+
+        widget::container(
+            widget::row::with_capacity(3)
+                .push(widget::text(label).width(Length::Fill))
+                .push(widget::text(fl!(
+                    "deletion-countdown",
+                    seconds = pending.seconds_remaining
+                )))
+                .push(widget::button::standard(fl!("undo")).on_press(Message::TaskDeletionUndo))
+                .align_y(Alignment::Center)
+                .spacing(spacing.space_s),
+        )
+        .class(cosmic::style::Container::Primary)
+        .padding(spacing.space_xxxs)
+        .width(Length::Fill)
+        .into()
+    }
+
+    fn empty_view(&self) -> Element<'_, Message> {
+        widget::container(
+            widget::column::with_children(vec![
+                widget::icon::from_name("user-trash-symbolic")
+                    .size(56)
+                    .into(),
+                widget::text::title1(fl!("no-trash")).into(),
+                widget::text(fl!("no-trash-suggestion")).into(),
+            ])
+            .spacing(10)
+            .align_x(Alignment::Center),
+        )
+        .align_y(Vertical::Center)
+        .align_x(Horizontal::Center)
+        .height(Length::Fill)
+        .width(Length::Fill)
+        .into()
+    }
+}

--- a/src/services/store.rs
+++ b/src/services/store.rs
@@ -1,4 +1,4 @@
-use crate::model::{List, Task};
+use crate::model::{List, Task, TrashedTask};
 use crate::StoreError;
 use crate::{Error, Result};
 use ron::ser::PrettyConfig;
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 const LISTS_REGISTRY: &str = "lists.ron";
+const TRASH_DIR: &str = "_trash";
 
 fn pretty() -> PrettyConfig {
     PrettyConfig::new().depth_limit(6).struct_names(true)
@@ -28,6 +29,10 @@ impl Store {
         ListStore { store: self }
     }
 
+    pub fn trash(&self) -> TrashStore<'_> {
+        TrashStore { store: self }
+    }
+
     pub fn tasks(&self, list_id: Uuid) -> TaskStore<'_> {
         TaskStore {
             store: self,
@@ -39,12 +44,65 @@ impl Store {
         self.base_dir.join(LISTS_REGISTRY)
     }
 
+    fn trash_dir(&self) -> PathBuf {
+        self.base_dir.join(TRASH_DIR)
+    }
+
+    fn trashed_task_path(&self, task_id: Uuid) -> PathBuf {
+        self.trash_dir().join(format!("{task_id}.ron"))
+    }
+
     fn list_dir(&self, list_id: Uuid) -> PathBuf {
         self.base_dir.join(list_id.to_string())
     }
 
     fn task_path(&self, list_id: Uuid, task_id: Uuid) -> PathBuf {
         self.list_dir(list_id).join(format!("{task_id}.ron"))
+    }
+}
+
+pub struct TrashStore<'s> {
+    store: &'s Store,
+}
+
+impl TrashStore<'_> {
+    /// Persist a trashed task.
+    pub fn save(&self, trashed: &TrashedTask) -> crate::Result<()> {
+        fs::create_dir_all(self.store.trash_dir())?;
+        let path = self.store.trashed_task_path(trashed.task.id);
+        let content = ron::ser::to_string_pretty(trashed, pretty())?;
+        fs::write(path, content)?;
+        Ok(())
+    }
+
+    /// Load all trashed tasks, sorted newest-first.
+    pub fn load_all(&self) -> crate::Result<Vec<TrashedTask>> {
+        let trash_dir = self.store.trash_dir();
+        if !trash_dir.exists() {
+            return Ok(vec![]);
+        }
+        let mut tasks = Vec::new();
+        for entry in fs::read_dir(&trash_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("ron") {
+                continue;
+            }
+            match fs::read_to_string(&path).map(|s| ron::from_str::<TrashedTask>(&s)) {
+                Ok(Ok(task)) => tasks.push(task),
+                Ok(Err(e)) => tracing::error!("skipping {:?}: {e}", path.file_name()),
+                Err(e) => tracing::error!("could not read {:?}: {e}", path.file_name()),
+            }
+        }
+        tasks.sort_by(|a, b| b.deleted_at.cmp(&a.deleted_at));
+        Ok(tasks)
+    }
+
+    /// Permanently delete a single trashed task.
+    pub fn delete(&self, task_id: Uuid) -> crate::Result<()> {
+        let path = self.store.trashed_task_path(task_id);
+        fs::remove_file(&path)
+            .map_err(|_| crate::Error::Store(crate::StoreError::TaskNotFound(task_id)))
     }
 }
 


### PR DESCRIPTION
This PR introduces **Trash**, a special list that handles all deleted tasks, with support for restoring and permanently deleting them. It's an exciting one, as it finally closes #34, which has been a long time coming!

<img width="802" height="743" alt="Screenshot_2026-05-04_12-42-57" src="https://github.com/user-attachments/assets/c161d96b-c435-4d51-8a80-a74c66b1e1de" />
