### PR TITLE
feat: favorites list

### DIFF
--- a/i18n/en/tasks.ftl
+++ b/i18n/en/tasks.ftl
@@ -1,6 +1,9 @@
 tasks = Tasks
+favorites = Favorites
 trash = Trash
 empty-trash = Empty trash
+no-favorites = No favorites
+no-favorites-suggestion = Mark tasks as favorites to see them here
 no-trash = Trash is empty
 no-trash-suggestion = Deleted tasks will appear here
 restore = Restore

--- a/i18n/en/tasks.ftl
+++ b/i18n/en/tasks.ftl
@@ -90,6 +90,7 @@ settings = Settings
 
 ### Appearance
 appearance = Appearance
+show-favorites = Show favorites
 theme = Theme
 match-desktop = Match desktop
 dark = Dark

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,7 +20,7 @@ use crate::{
     config::AppConfig,
     fl,
     model::List,
-    pages::{content, details, trash},
+    pages::{content, details, favorites, trash},
 };
 
 impl Application for AppModel {
@@ -80,6 +80,9 @@ impl Application for AppModel {
         &self,
         id: widget::nav_bar::Id,
     ) -> Option<Vec<widget::menu::Tree<cosmic::Action<Self::Message>>>> {
+        if self.nav.data::<crate::model::FavoritesMarker>(id).is_some() {
+            return None;
+        }
         if self.nav.data::<crate::model::TrashMarker>(id).is_some() {
             return navigation::trash_context_menu();
         }
@@ -103,6 +106,16 @@ impl Application for AppModel {
     fn on_nav_select(&mut self, entity: Entity) -> app::Task<Self::Message> {
         let mut tasks = vec![];
         self.nav.activate(entity);
+
+        // Check if favorites was selected
+        if self
+            .nav
+            .data::<crate::model::FavoritesMarker>(entity)
+            .is_some()
+        {
+            let _ = self.update(Message::Content(content::Message::SetList(None)));
+            return self.update(Message::Favorites(favorites::Message::Load));
+        }
 
         // Check if trash was selected
         if self.nav.data::<crate::model::TrashMarker>(entity).is_some() {
@@ -256,6 +269,9 @@ impl Application for AppModel {
             Message::Trash(msg) => {
                 self.trash.update(msg);
             }
+            Message::Favorites(msg) => {
+                self.favorites.update(msg);
+            }
             Message::Tasks(action) => {
                 return self.update_tasks(action);
             }
@@ -294,6 +310,12 @@ impl Application for AppModel {
             .is_some()
         {
             self.trash.view().map(Message::Trash)
+        } else if self
+            .nav
+            .active_data::<crate::model::FavoritesMarker>()
+            .is_some()
+        {
+            self.favorites.view().map(Message::Favorites)
         } else {
             self.content.view().map(Message::Content)
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -270,7 +270,44 @@ impl Application for AppModel {
                 self.trash.update(msg);
             }
             Message::Favorites(msg) => {
-                self.favorites.update(msg);
+                if let Some(output) = self.favorites.update(msg) {
+                    match output {
+                        favorites::Output::OpenTask { task, list_id } => {
+                            // Find the nav entity for this list and activate it.
+                            let entity = self.nav.iter().find(|e| {
+                                self.nav
+                                    .data::<crate::model::List>(*e)
+                                    .is_some_and(|l| l.id == list_id)
+                            });
+                            let Some(entity) = entity else {
+                                tracing::error!("Nav entity not found for list {list_id}");
+                                return app::Task::none();
+                            };
+                            self.nav.activate(entity);
+
+                            let mut tasks = vec![cosmic::task::message(
+                                Message::ToggleContextPage(ContextPage::TaskDetails),
+                            )];
+
+                            if let Some(list) = self.nav.data::<crate::model::List>(entity) {
+                                tasks.push(self.update(Message::Content(
+                                    content::Message::SetList(Some(list.clone())),
+                                )));
+                            }
+
+                            let Some(key) = self.content.find_task_key(task.id) else {
+                                tracing::error!("Task key not found after loading list");
+                                return app::Task::none();
+                            };
+
+                            tasks.push(cosmic::task::message(Message::Details(
+                                details::Message::SetTask(key, task, list_id),
+                            )));
+
+                            return app::Task::batch(tasks);
+                        }
+                    }
+                }
             }
             Message::Tasks(action) => {
                 return self.update_tasks(action);

--- a/src/app/core/init.rs
+++ b/src/app/core/init.rs
@@ -54,17 +54,7 @@ impl AppModel {
 
         app.core.nav_bar_toggle_condensed();
 
-        let favorites_icon = widget::icon::from_name("starred-symbolic").size(16);
-        app.favorites_entity = app
-            .nav
-            .insert()
-            .text(fl!("favorites"))
-            .icon(favorites_icon)
-            .data(crate::model::FavoritesMarker)
-            .id();
-
-        // Insert the trash nav item and remember its entity so we can always
-        // reposition it to the bottom after new lists are added.
+        // Insert the trash nav item.
         let trash_icon = widget::icon::from_name("user-trash-full-symbolic").size(16);
         app.trash_entity = app
             .nav
@@ -73,6 +63,11 @@ impl AppModel {
             .icon(trash_icon)
             .data(crate::model::TrashMarker)
             .id();
+
+        // Conditionally insert the favorites nav item based on config.
+        if app.config.show_favorites {
+            app.show_favorites_nav_item();
+        }
 
         (app, app::Task::batch(tasks))
     }

--- a/src/app/core/init.rs
+++ b/src/app/core/init.rs
@@ -13,7 +13,7 @@ use cosmic::{
 use crate::{
     app::{navigation::TasksAction, ui::MenuAction},
     fl,
-    pages::{content::Content, details::Details, trash::Trash},
+    pages::{content::Content, details::Details, favorites::Favorites, trash::Trash},
 };
 
 use super::{context::ContextPage, flags::Flags, message::Message, model::AppModel};
@@ -35,11 +35,13 @@ impl AppModel {
             store: flags.store.clone(),
             content: Content::new(flags.store.clone(), flags.config),
             details: Details::new(flags.store.clone()),
-            trash: Trash::new(flags.store),
+            trash: Trash::new(flags.store.clone()),
             modifiers: Modifiers::empty(),
             dialog_pages: VecDeque::new(),
             dialog_text_input: widget::Id::unique(),
             trash_entity: widget::segmented_button::Entity::default(),
+            favorites: Favorites::new(flags.store.clone()),
+            favorites_entity: widget::segmented_button::Entity::default(),
         };
 
         let mut tasks = vec![cosmic::task::message(Message::Tasks(
@@ -51,6 +53,15 @@ impl AppModel {
         }
 
         app.core.nav_bar_toggle_condensed();
+
+        let favorites_icon = widget::icon::from_name("starred-symbolic").size(16);
+        app.favorites_entity = app
+            .nav
+            .insert()
+            .text(fl!("favorites"))
+            .icon(favorites_icon)
+            .data(crate::model::FavoritesMarker)
+            .id();
 
         // Insert the trash nav item and remember its entity so we can always
         // reposition it to the bottom after new lists are added.

--- a/src/app/core/message.rs
+++ b/src/app/core/message.rs
@@ -5,7 +5,7 @@ use crate::{
         ui::{ApplicationAction, MenuAction},
     },
     config::AppConfig,
-    pages::{content, details, trash},
+    pages::{content, details, favorites, trash},
 };
 
 use super::ContextPage;
@@ -24,4 +24,5 @@ pub enum Message {
     Open(String),
     UpdateConfig(AppConfig),
     Trash(trash::Message),
+    Favorites(favorites::Message),
 }

--- a/src/app/core/model.rs
+++ b/src/app/core/model.rs
@@ -10,7 +10,7 @@ use cosmic::{
 use crate::{
     app::{dialogs::DialogPage, ui::MenuAction},
     config,
-    pages::{content::Content, details::Details, trash::Trash},
+    pages::{content::Content, details::Details, favorites::Favorites, trash::Trash},
     services::store::Store,
 };
 
@@ -49,4 +49,8 @@ pub struct AppModel {
     pub(crate) trash: Trash,
     /// The nav bar entity for the trash item (kept so we can always reposition it last).
     pub(crate) trash_entity: nav_bar::Id,
+    /// The favorites page.
+    pub(crate) favorites: Favorites,
+    /// The nav bar entity for the favorites item.
+    pub(crate) favorites_entity: nav_bar::Id,
 }

--- a/src/app/navigation/helpers.rs
+++ b/src/app/navigation/helpers.rs
@@ -19,16 +19,16 @@ impl AppModel {
             .data(list.clone())
     }
 
-    /// Pin the trash entity to position 0 and place a divider below it
-    /// (i.e. divider_above on the item at position 1) so it is visually
-    /// separated from the list items beneath it.
-    pub fn reposition_trash(&mut self) {
-        self.nav.position_set(self.trash_entity, 0);
-        // Sweep all entities: only the item immediately after trash (index 1)
-        // gets a divider_above so the separator appears between trash and lists.
+    /// Pin the special nav items (favorites, trash) to the top of the nav bar
+    /// and place a single divider below them, above the first list item.
+    /// Called after every list insertion.
+    pub fn reposition_special_items(&mut self) {
+        self.nav.position_set(self.favorites_entity, 0);
+        self.nav.position_set(self.trash_entity, 1);
+        // Only the item at position 2 (first list) gets a divider above it.
         let entities: Vec<_> = self.nav.iter().collect();
         for (i, entity) in entities.iter().enumerate() {
-            self.nav.divider_above_set(*entity, i == 1);
+            self.nav.divider_above_set(*entity, i == 2);
         }
     }
 

--- a/src/app/navigation/helpers.rs
+++ b/src/app/navigation/helpers.rs
@@ -5,6 +5,7 @@ use cosmic::widget::{
 
 use crate::{
     app::{core::AppModel, ui::Markdown},
+    fl,
     model::List,
 };
 
@@ -19,16 +20,41 @@ impl AppModel {
             .data(list.clone())
     }
 
-    /// Pin the special nav items (favorites, trash) to the top of the nav bar
-    /// and place a single divider below them, above the first list item.
-    /// Called after every list insertion.
+    /// Insert the favorites nav item and store its entity.
+    pub fn show_favorites_nav_item(&mut self) {
+        let icon = widget::icon::from_name("starred-symbolic").size(16);
+        self.favorites_entity = self
+            .nav
+            .insert()
+            .text(fl!("favorites"))
+            .icon(icon)
+            .data(crate::model::FavoritesMarker)
+            .id();
+        self.reposition_special_items();
+    }
+
+    /// Remove the favorites nav item.
+    pub fn hide_favorites_nav_item(&mut self) {
+        self.nav.remove(self.favorites_entity);
+        self.reposition_special_items();
+    }
+
+    /// Pin the special nav items to the top of the nav bar and place a single
+    /// divider below them, above the first list item. When favorites is hidden
+    /// trash sits at position 0; when shown, favorites is 0 and trash is 1.
     pub fn reposition_special_items(&mut self) {
-        self.nav.position_set(self.favorites_entity, 0);
-        self.nav.position_set(self.trash_entity, 1);
-        // Only the item at position 2 (first list) gets a divider above it.
+        let first_list_pos: u16 = if self.config.show_favorites {
+            self.nav.position_set(self.favorites_entity, 0);
+            self.nav.position_set(self.trash_entity, 1);
+            2
+        } else {
+            self.nav.position_set(self.trash_entity, 0);
+            1
+        };
         let entities: Vec<_> = self.nav.iter().collect();
         for (i, entity) in entities.iter().enumerate() {
-            self.nav.divider_above_set(*entity, i == 2);
+            self.nav
+                .divider_above_set(*entity, i == first_list_pos as usize);
         }
     }
 

--- a/src/app/navigation/update.rs
+++ b/src/app/navigation/update.rs
@@ -29,7 +29,7 @@ impl AppModel {
                 for list in lists {
                     self.create_nav_item(&list);
                 }
-                self.reposition_trash();
+                self.reposition_special_items();
                 let Some(entity) = self.nav.iter().next() else {
                     return app::Task::none();
                 };
@@ -38,7 +38,7 @@ impl AppModel {
             }
             TasksAction::AddList(list) => {
                 self.create_nav_item(&list);
-                self.reposition_trash();
+                self.reposition_special_items();
                 // Select the newly added list, which is now second-to-last
                 // (last is always trash). Find it by its data.
                 let entity = self

--- a/src/app/ui/actions.rs
+++ b/src/app/ui/actions.rs
@@ -27,6 +27,7 @@ pub enum ApplicationAction {
     Key(Modifiers, Key),
     Modifiers(Modifiers),
     AppTheme(usize),
+    ToggleShowFavorites(bool),
 }
 
 impl Action for MenuAction {

--- a/src/app/ui/menu.rs
+++ b/src/app/ui/menu.rs
@@ -131,19 +131,6 @@ pub fn menu_bar<'a>(state: &AppModel) -> Element<'a, Message> {
                         MenuAction::Settings,
                     ),
                     Item::Divider,
-                    list_selected
-                        .then_some(Item::CheckBox(
-                            fl!("hide-completed"),
-                            None,
-                            state.config.hide_completed,
-                            MenuAction::ToggleHideCompleted(!&state.config.hide_completed),
-                        ))
-                        .unwrap_or(Item::ButtonDisabled(
-                            fl!("hide-completed"),
-                            None,
-                            MenuAction::ToggleHideCompleted(!&state.config.hide_completed),
-                        )),
-                    Item::Divider,
                     Item::Button(
                         fl!("menu-about"),
                         Some(

--- a/src/app/ui/update.rs
+++ b/src/app/ui/update.rs
@@ -1,6 +1,6 @@
 use std::{env, process};
 
-use cosmic::{app, widget::menu::Action as _};
+use cosmic::{app, widget::menu::Action as _, Application};
 
 use crate::{
     app::{
@@ -20,6 +20,34 @@ impl AppModel {
                     tracing::error!("{err}")
                 }
                 return cosmic::command::set_theme(self.config.app_theme.theme());
+            }
+            ApplicationAction::ToggleShowFavorites(show) => {
+                if let Err(err) = self.config.set_show_favorites(&self.handler, show) {
+                    tracing::error!("{err}");
+                }
+                if show {
+                    self.show_favorites_nav_item();
+                } else {
+                    // Remove the nav item unconditionally first.
+                    self.hide_favorites_nav_item();
+                    // If the user was viewing favorites, navigate them to the first list.
+                    if self
+                        .nav
+                        .active_data::<crate::model::FavoritesMarker>()
+                        .is_some()
+                    {
+                        let entity = self
+                            .nav
+                            .iter()
+                            .find(|e| self.nav.data::<crate::model::List>(*e).is_some())
+                            .unwrap_or_else(|| self.nav.iter().last().unwrap_or_default());
+                        return self.update(crate::app::core::Message::Content(
+                            crate::pages::content::Message::SetList(
+                                self.nav.data::<crate::model::List>(entity).cloned(),
+                            ),
+                        ));
+                    }
+                }
             }
             ApplicationAction::Key(modifiers, key) => {
                 for (key_bind, action) in self.key_binds.clone().into_iter() {

--- a/src/app/ui/views.rs
+++ b/src/app/ui/views.rs
@@ -3,21 +3,34 @@ use cosmic::{widget, Element};
 use crate::{
     app::{
         core::{AppModel, Message},
-        ui::ApplicationAction,
+        ui::{ApplicationAction, MenuAction},
     },
     fl,
 };
 
 pub fn settings(app: &AppModel) -> Element<'_, Message> {
-    widget::scrollable(widget::settings::section().title(fl!("appearance")).add(
-        widget::settings::item::item(
-            fl!("theme"),
-            widget::dropdown(
-                vec![fl!("match-desktop"), fl!("dark"), fl!("light")],
-                Some(app.config.app_theme.into()),
-                |theme| Message::Application(ApplicationAction::AppTheme(theme)),
-            ),
-        ),
-    ))
+    widget::scrollable(
+        widget::settings::section()
+            .title(fl!("appearance"))
+            .add(widget::settings::item::item(
+                fl!("theme"),
+                widget::dropdown(
+                    vec![fl!("match-desktop"), fl!("dark"), fl!("light")],
+                    Some(app.config.app_theme.into()),
+                    |theme| Message::Application(ApplicationAction::AppTheme(theme)),
+                ),
+            ))
+            .add(widget::settings::item::item(
+                fl!("show-favorites"),
+                widget::toggler(app.config.show_favorites).on_toggle(|val| {
+                    Message::Application(ApplicationAction::ToggleShowFavorites(val))
+                }),
+            ))
+            .add(widget::settings::item::item(
+                fl!("hide-completed"),
+                widget::toggler(app.config.hide_completed)
+                    .on_toggle(|val| Message::Menu(MenuAction::ToggleHideCompleted(val))),
+            )),
+    )
     .into()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,10 +6,21 @@ use serde::{Deserialize, Serialize};
 
 pub const CONFIG_VERSION: u64 = 1;
 
-#[derive(Clone, Default, Debug, Eq, PartialEq, Deserialize, Serialize, CosmicConfigEntry)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, CosmicConfigEntry)]
 pub struct AppConfig {
     pub app_theme: AppTheme,
     pub hide_completed: bool,
+    pub show_favorites: bool,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            app_theme: AppTheme::default(),
+            hide_completed: false,
+            show_favorites: true,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -6,3 +6,6 @@ pub use task::*;
 
 /// Zero-sized marker struct to tag the trash nav item.
 pub struct TrashMarker;
+
+/// Zero-sized marker struct to tag the favorites nav item.
+pub struct FavoritesMarker;

--- a/src/pages/content.rs
+++ b/src/pages/content.rs
@@ -62,6 +62,7 @@ pub enum Message {
     TaskExpand(DefaultKey),
     TaskAddSubTask(DefaultKey),
     TaskComplete(DefaultKey, bool),
+    TaskToggleFavorite(DefaultKey),
     TaskToggleTitleEditMode(DefaultKey, bool),
     TaskTitleInput(String),
     TaskOpenDetails(DefaultKey),
@@ -359,6 +360,23 @@ impl Content {
                     }
                 }
             }
+            Message::TaskToggleFavorite(id) => {
+                let Some(list) = &self.selected_list else {
+                    tracing::warn!("No list selected");
+                    return None;
+                };
+
+                if let Some(task) = self.tasks.get_mut(id) {
+                    task.favorite = !task.favorite;
+                    if let Err(error) = self
+                        .store
+                        .tasks(list.id)
+                        .update(task.id, |t| t.favorite = task.favorite)
+                    {
+                        tracing::error!("Failed to update task favorite: {:?}", error);
+                    }
+                }
+            }
             Message::TaskAddSubTask(id) => {
                 let Some(list) = &self.selected_list else {
                     tracing::warn!("No list selected");
@@ -431,6 +449,14 @@ impl Content {
             search_query: String::new(),
             sort_type: SortType::DateAsc,
         }
+    }
+
+    /// Find the slotmap key for a task by its UUID, if it is currently loaded.
+    pub fn find_task_key(&self, task_id: uuid::Uuid) -> Option<DefaultKey> {
+        self.tasks
+            .iter()
+            .find(|(_, t)| t.id == task_id)
+            .map(|(k, _)| k)
     }
 
     /// Creates the main list view with tasks
@@ -631,9 +657,10 @@ impl Content {
         let title_input = self.create_task_title_input(id, task);
         let expand_button = self.create_expand_button(id, task, sub_tasks, spacing);
         let subtask_count = self.create_subtask_counter(sub_tasks);
+        let favorite_button = self.create_favorite_button(id, task, spacing);
         let menu = self.create_task_menu(id);
 
-        widget::row::with_capacity(5)
+        widget::row::with_capacity(6)
             .align_y(Alignment::Center)
             .spacing(spacing.space_xxxs)
             .padding([spacing.space_xxxs, spacing.space_xs])
@@ -641,6 +668,7 @@ impl Content {
             .push(title_input)
             .push_maybe(expand_button)
             .push_maybe(subtask_count)
+            .push(favorite_button)
             .push(menu)
             .into()
     }
@@ -653,6 +681,24 @@ impl Content {
     ) -> Element<'a, Message> {
         widget::checkbox(task.status == Status::Completed)
             .on_toggle(move |value| Message::TaskComplete(id, value))
+            .into()
+    }
+
+    /// Creates a star button to toggle the favorite state of a task.
+    fn create_favorite_button<'a>(
+        &'a self,
+        id: DefaultKey,
+        task: &'a model::Task,
+        spacing: &Spacing,
+    ) -> Element<'a, Message> {
+        let icon_name = if task.favorite {
+            "starred-symbolic"
+        } else {
+            "non-starred-symbolic"
+        };
+        widget::button::icon(widget::icon::from_name(icon_name).size(16))
+            .padding(spacing.space_xxs)
+            .on_press(Message::TaskToggleFavorite(id))
             .into()
     }
 

--- a/src/pages/favorites.rs
+++ b/src/pages/favorites.rs
@@ -1,0 +1,216 @@
+use cosmic::{
+    iced::{
+        alignment::{Horizontal, Vertical},
+        Alignment, Length,
+    },
+    theme, widget, Apply, Element,
+};
+
+use uuid::Uuid;
+
+use crate::{
+    fl,
+    model::{List, Task},
+    services::store::Store,
+};
+
+/// A favorite task together with the name and id of the list it belongs to.
+pub struct FavoriteEntry {
+    pub task: Task,
+    pub list_id: Uuid,
+    pub list_name: String,
+}
+
+pub struct Favorites {
+    entries: Vec<FavoriteEntry>,
+    store: Store,
+}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    Load,
+    Loaded(Vec<FavoriteEntry>),
+    Unfavorite(Uuid),
+}
+
+impl std::fmt::Debug for FavoriteEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FavoriteEntry")
+            .field("task_id", &self.task.id)
+            .field("list_name", &self.list_name)
+            .finish()
+    }
+}
+
+impl Clone for FavoriteEntry {
+    fn clone(&self) -> Self {
+        Self {
+            task: self.task.clone(),
+            list_id: self.list_id,
+            list_name: self.list_name.clone(),
+        }
+    }
+}
+
+impl Favorites {
+    pub fn new(store: Store) -> Self {
+        Self {
+            entries: Vec::new(),
+            store,
+        }
+    }
+
+    pub fn update(&mut self, message: Message) {
+        match message {
+            Message::Load => {
+                let lists: Vec<List> = self.store.lists().load_all().unwrap_or_else(|e| {
+                    tracing::error!("Failed to load lists for favorites: {e}");
+                    vec![]
+                });
+
+                let mut entries = Vec::new();
+                for list in &lists {
+                    let tasks = self.store.tasks(list.id).load_all().unwrap_or_else(|e| {
+                        tracing::error!("Failed to load tasks for list {}: {e}", list.id);
+                        vec![]
+                    });
+                    for task in tasks {
+                        if task.favorite {
+                            entries.push(FavoriteEntry {
+                                task,
+                                list_id: list.id,
+                                list_name: list.name.clone(),
+                            });
+                        }
+                    }
+                }
+
+                // Sort by list name then task title for a stable, predictable order.
+                entries.sort_by(|a, b| {
+                    a.list_name
+                        .cmp(&b.list_name)
+                        .then_with(|| a.task.title.cmp(&b.task.title))
+                });
+
+                self.update(Message::Loaded(entries));
+            }
+            Message::Loaded(entries) => {
+                self.entries = entries;
+            }
+            Message::Unfavorite(task_id) => {
+                if let Some(pos) = self.entries.iter().position(|e| e.task.id == task_id) {
+                    let list_id = self.entries[pos].list_id;
+                    if let Err(e) = self
+                        .store
+                        .tasks(list_id)
+                        .update(task_id, |t| t.favorite = false)
+                    {
+                        tracing::error!("Failed to unfavorite task: {e}");
+                    } else {
+                        self.entries.remove(pos);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn view(&self) -> Element<'_, Message> {
+        if self.entries.is_empty() {
+            return self.empty_view();
+        }
+
+        let spacing = theme::active().cosmic().spacing;
+
+        let header = self.header_view();
+
+        let rows: Vec<Element<'_, Message>> =
+            self.entries.iter().map(|e| self.entry_row(e)).collect();
+
+        let list = widget::column::with_children(rows).spacing(spacing.space_xxs);
+
+        let content = widget::column::with_capacity(2)
+            .push(header)
+            .push(widget::scrollable(list).height(Length::Fill))
+            .spacing(spacing.space_s)
+            .padding([spacing.space_xxs, spacing.space_xxxs]);
+
+        widget::container(content)
+            .height(Length::Fill)
+            .width(Length::Fill)
+            .center_x(Length::Fill)
+            .max_width(800.)
+            .apply(widget::container)
+            .height(Length::Fill)
+            .width(Length::Fill)
+            .center(Length::Fill)
+            .into()
+    }
+
+    fn header_view(&self) -> Element<'_, Message> {
+        let spacing = theme::active().cosmic().spacing;
+
+        let icon = widget::icon::from_name("starred-symbolic").size(spacing.space_m);
+        let title = widget::text::body(fl!("favorites"))
+            .size(24)
+            .width(Length::Fill);
+
+        widget::row::with_capacity(2)
+            .align_y(Alignment::Center)
+            .spacing(spacing.space_s)
+            .padding([spacing.space_none, spacing.space_xxs])
+            .push(icon)
+            .push(title)
+            .into()
+    }
+
+    fn entry_row<'a>(&'a self, entry: &'a FavoriteEntry) -> Element<'a, Message> {
+        let spacing = theme::active().cosmic().spacing;
+
+        let task_id = entry.task.id;
+        let star_button =
+            widget::button::icon(widget::icon::from_name("starred-symbolic").size(16))
+                .padding(spacing.space_xxs)
+                .on_press(Message::Unfavorite(task_id));
+
+        let title = widget::text::body(entry.task.title.as_str()).width(Length::Fill);
+        let list_label = widget::text(entry.list_name.as_str())
+            .size(12)
+            .class(cosmic::style::Text::Default);
+
+        let text_col = widget::column::with_capacity(2)
+            .push(title)
+            .push(list_label)
+            .width(Length::Fill);
+
+        let row = widget::row::with_capacity(2)
+            .align_y(Alignment::Center)
+            .spacing(spacing.space_s)
+            .padding([spacing.space_xxxs, spacing.space_xs])
+            .push(star_button)
+            .push(text_col);
+
+        widget::container(row)
+            .class(cosmic::style::Container::ContextDrawer)
+            .width(Length::Fill)
+            .into()
+    }
+
+    fn empty_view(&self) -> Element<'_, Message> {
+        widget::container(
+            widget::column::with_children(vec![
+                widget::icon::from_name("non-starred-symbolic")
+                    .size(56)
+                    .into(),
+                widget::text::title1(fl!("no-favorites")).into(),
+                widget::text(fl!("no-favorites-suggestion")).into(),
+            ])
+            .spacing(10)
+            .align_x(Alignment::Center),
+        )
+        .align_y(Vertical::Center)
+        .align_x(Horizontal::Center)
+        .height(Length::Fill)
+        .width(Length::Fill)
+        .into()
+    }
+}

--- a/src/pages/favorites.rs
+++ b/src/pages/favorites.rs
@@ -31,6 +31,12 @@ pub enum Message {
     Load,
     Loaded(Vec<FavoriteEntry>),
     Unfavorite(Uuid),
+    /// Navigate to the task's list and open its details pane.
+    Open(Uuid),
+}
+
+pub enum Output {
+    OpenTask { task: Task, list_id: Uuid },
 }
 
 impl std::fmt::Debug for FavoriteEntry {
@@ -60,7 +66,7 @@ impl Favorites {
         }
     }
 
-    pub fn update(&mut self, message: Message) {
+    pub fn update(&mut self, message: Message) -> Option<Output> {
         match message {
             Message::Load => {
                 let lists: Vec<List> = self.store.lists().load_all().unwrap_or_else(|e| {
@@ -111,7 +117,16 @@ impl Favorites {
                     }
                 }
             }
+            Message::Open(task_id) => {
+                if let Some(entry) = self.entries.iter().find(|e| e.task.id == task_id) {
+                    return Some(Output::OpenTask {
+                        task: entry.task.clone(),
+                        list_id: entry.list_id,
+                    });
+                }
+            }
         }
+        None
     }
 
     pub fn view(&self) -> Element<'_, Message> {
@@ -182,12 +197,18 @@ impl Favorites {
             .push(list_label)
             .width(Length::Fill);
 
-        let row = widget::row::with_capacity(2)
+        let open_button =
+            widget::button::icon(widget::icon::from_name("go-next-symbolic").size(16))
+                .padding(spacing.space_xxs)
+                .on_press(Message::Open(task_id));
+
+        let row = widget::row::with_capacity(3)
             .align_y(Alignment::Center)
             .spacing(spacing.space_s)
             .padding([spacing.space_xxxs, spacing.space_xs])
             .push(star_button)
-            .push(text_col);
+            .push(text_col)
+            .push(open_button);
 
         widget::container(row)
             .class(cosmic::style::Container::ContextDrawer)

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -1,3 +1,4 @@
 pub mod content;
 pub mod details;
+pub mod favorites;
 pub mod trash;


### PR DESCRIPTION
This pull request introduces a new "Favorites" feature to the application, allowing users to mark tasks as favorites and access them from a dedicated view.

**Changes**
* Added a new `Favorites` page.
* Added a **favorite** toggle button to tasks.
* Favorites have a button that opens the edit pane.
* Refactored the navigation bar to support both Trash and Favorites as special items.
* Updated the settings UI to include toggles for "Show favorites" and "Hide completed" tasks.

**Screenshots**

<img width="774" height="727" alt="Screenshot_2026-05-04_13-18-58" src="https://github.com/user-attachments/assets/2a7b669c-134e-4680-9516-c3d7529f4e36" />


<img width="774" height="727" alt="Screenshot_2026-05-04_13-19-02" src="https://github.com/user-attachments/assets/2630ca86-37ab-4014-a608-2d16b54c30f5" />

Closes #97