### PR TITLE
feat: add persistent sorting

### DIFF
--- a/src/app/ui/menu.rs
+++ b/src/app/ui/menu.rs
@@ -10,6 +10,7 @@ use cosmic::{
 
 use crate::{
     app::{core::Message, ui::MenuAction, AppModel},
+    config::SortBy,
     fl,
     model::List,
 };
@@ -149,10 +150,30 @@ pub fn menu_bar<'a>(state: &AppModel) -> Element<'a, Message> {
                 &state.key_binds,
                 list_selected
                     .then_some(vec![
-                        Item::Button(fl!("sort-name-asc"), None, MenuAction::SortByNameAsc),
-                        Item::Button(fl!("sort-name-desc"), None, MenuAction::SortByNameDesc),
-                        Item::Button(fl!("sort-date-asc"), None, MenuAction::SortByDateAsc),
-                        Item::Button(fl!("sort-date-desc"), None, MenuAction::SortByDateDesc),
+                        Item::CheckBox(
+                            fl!("sort-name-asc"),
+                            None,
+                            state.config.sort_by == SortBy::NameAsc,
+                            MenuAction::SortByNameAsc,
+                        ),
+                        Item::CheckBox(
+                            fl!("sort-name-desc"),
+                            None,
+                            state.config.sort_by == SortBy::NameDesc,
+                            MenuAction::SortByNameDesc,
+                        ),
+                        Item::CheckBox(
+                            fl!("sort-date-asc"),
+                            None,
+                            state.config.sort_by == SortBy::DateAsc,
+                            MenuAction::SortByDateAsc,
+                        ),
+                        Item::CheckBox(
+                            fl!("sort-date-desc"),
+                            None,
+                            state.config.sort_by == SortBy::DateDesc,
+                            MenuAction::SortByDateDesc,
+                        ),
                     ])
                     .unwrap_or(vec![
                         Item::ButtonDisabled(fl!("sort-name-asc"), None, MenuAction::SortByNameAsc),

--- a/src/app/ui/update.rs
+++ b/src/app/ui/update.rs
@@ -7,6 +7,7 @@ use crate::{
         core::{AppModel, ContextPage, Message},
         dialogs::{DialogAction, DialogPage},
     },
+    config,
     pages::content,
 };
 
@@ -117,23 +118,47 @@ impl AppModel {
                 )));
             }
             MenuAction::SortByNameAsc => {
+                if let Err(err) = self
+                    .config
+                    .set_sort_by(&self.handler, config::SortBy::NameAsc)
+                {
+                    tracing::error!("{err}")
+                }
                 return cosmic::task::message(Message::Content(content::Message::SetSort(
-                    content::SortType::NameAsc,
+                    content::SortBy::NameAsc,
                 )));
             }
             MenuAction::SortByNameDesc => {
+                if let Err(err) = self
+                    .config
+                    .set_sort_by(&self.handler, config::SortBy::NameDesc)
+                {
+                    tracing::error!("{err}")
+                }
                 return cosmic::task::message(Message::Content(content::Message::SetSort(
-                    content::SortType::NameDesc,
+                    content::SortBy::NameDesc,
                 )));
             }
             MenuAction::SortByDateAsc => {
+                if let Err(err) = self
+                    .config
+                    .set_sort_by(&self.handler, config::SortBy::DateAsc)
+                {
+                    tracing::error!("{err}")
+                }
                 return cosmic::task::message(Message::Content(content::Message::SetSort(
-                    content::SortType::DateAsc,
+                    content::SortBy::DateAsc,
                 )));
             }
             MenuAction::SortByDateDesc => {
+                if let Err(err) = self
+                    .config
+                    .set_sort_by(&self.handler, config::SortBy::DateDesc)
+                {
+                    tracing::error!("{err}")
+                }
                 return cosmic::task::message(Message::Content(content::Message::SetSort(
-                    content::SortType::DateDesc,
+                    content::SortBy::DateDesc,
                 )));
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,10 +7,12 @@ use serde::{Deserialize, Serialize};
 pub const CONFIG_VERSION: u64 = 1;
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, CosmicConfigEntry)]
+#[version = 1]
 pub struct AppConfig {
     pub app_theme: AppTheme,
     pub hide_completed: bool,
     pub show_favorites: bool,
+    pub sort_by: SortBy,
 }
 
 impl Default for AppConfig {
@@ -19,8 +21,19 @@ impl Default for AppConfig {
             app_theme: AppTheme::default(),
             hide_completed: false,
             show_favorites: true,
+            sort_by: SortBy::default(),
         }
     }
+}
+
+/// The sort order for tasks in the content view.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub enum SortBy {
+    NameAsc,
+    NameDesc,
+    #[default]
+    DateAsc,
+    DateDesc,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/pages/content.rs
+++ b/src/pages/content.rs
@@ -44,16 +44,10 @@ pub struct Content {
     search_bar_visible: bool,
     add_task_input: String,
     search_query: String,
-    sort_type: SortType,
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum SortType {
-    NameAsc,
-    NameDesc,
-    DateAsc,
-    DateDesc,
-}
+/// Re-export for convenience so callers can use `content::SortBy`.
+pub use crate::config::SortBy;
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -81,7 +75,7 @@ pub enum Message {
 
     ToggleSearchBar,
     SearchQueryChanged(String),
-    SetSort(SortType),
+    SetSort(SortBy),
 }
 
 pub enum Output {
@@ -427,8 +421,8 @@ impl Content {
                     }
                 }
             }
-            Message::SetSort(sort_type) => {
-                self.sort_type = sort_type;
+            Message::SetSort(sort_by) => {
+                self.config.sort_by = sort_by;
             }
         }
         output
@@ -447,7 +441,6 @@ impl Content {
             store: storage,
             search_bar_visible: false,
             search_query: String::new(),
-            sort_type: SortType::DateAsc,
         }
     }
 
@@ -559,15 +552,15 @@ impl Content {
     fn sort_tasks(&self) -> Vec<(DefaultKey, &model::Task)> {
         let mut tasks: Vec<_> = self.tasks.iter().collect();
 
-        match self.sort_type {
-            SortType::NameAsc => {
+        match self.config.sort_by {
+            SortBy::NameAsc => {
                 tasks.sort_by(|a, b| a.1.title.to_lowercase().cmp(&b.1.title.to_lowercase()))
             }
-            SortType::NameDesc => {
+            SortBy::NameDesc => {
                 tasks.sort_by(|a, b| b.1.title.to_lowercase().cmp(&a.1.title.to_lowercase()))
             }
-            SortType::DateAsc => tasks.sort_by(|a, b| a.1.creation_date.cmp(&b.1.creation_date)),
-            SortType::DateDesc => tasks.sort_by(|a, b| b.1.creation_date.cmp(&a.1.creation_date)),
+            SortBy::DateAsc => tasks.sort_by(|a, b| a.1.creation_date.cmp(&b.1.creation_date)),
+            SortBy::DateDesc => tasks.sort_by(|a, b| b.1.creation_date.cmp(&a.1.creation_date)),
         }
 
         tasks


### PR DESCRIPTION
This PR correctly reflects the active sort option using a checkmark. Additionally, the selected sort option is retained after restarting the application and resets to the default.

- Added `SortBy` enum.
- Added `sort_by` to AppConfig.
- Replace `SortType` with `crate::config::SortBy`.
- Change menu items to `CheckBox` and persist selection.
- Fixed a bug with config persistence, version was not specified.

Closes #89