### PR TITLE
feat: add reminder support with desktop notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,6 +2901,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+ "time",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3117,6 +3129,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "notify-types"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3330,6 +3356,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
+ "libc",
  "objc2 0.6.3",
  "objc2-core-foundation",
 ]
@@ -3874,6 +3901,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -4642,6 +4678,7 @@ dependencies = [
  "i18n-embed-fl",
  "jiff",
  "libcosmic",
+ "notify-rust",
  "open",
  "ron 0.11.0",
  "rust-embed",
@@ -4653,6 +4690,18 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
 ]
 
 [[package]]
@@ -5496,7 +5545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.38.4",
  "quote",
 ]
 
@@ -6077,6 +6126,15 @@ name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -6865,7 +6923,7 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "441a0064125265655bccc3a6af6bef56814d9277ac83fce48b1cd7e160b80eac"
 dependencies = [
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "zbus_names",
  "zvariant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ i18n-embed = { version = "0.16.0", features = [
     "desktop-requester",
 ] }
 jiff = { version = "0.2.24", features = ["serde"] }
+notify-rust = "4.17.0"
 
 [dependencies.rust-extensions]
 git = "https://github.com/edfloreshz/rust-extensions.git"

--- a/i18n/en/tasks.ftl
+++ b/i18n/en/tasks.ftl
@@ -68,6 +68,11 @@ search-icons = Search icons...
 
 # Date Dialog
 select-date = Select a date
+select-date-time = Select date and time
+hour = Hour
+minute = Minute
+set-reminder = Set reminder
+clear-reminder = Clear reminder
 
 # Export Dialog
 export = Export

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,6 +21,7 @@ use crate::{
     fl,
     model::List,
     pages::{content, details, favorites, trash},
+    services::reminder,
 };
 
 impl Application for AppModel {
@@ -171,6 +172,13 @@ impl Application for AppModel {
             );
         }
 
+        // Reminder subscription: ticks every 30 s so the update handler can
+        // scan tasks and fire desktop notifications for due reminders.
+        subscriptions.push(
+            cosmic::iced::time::every(std::time::Duration::from_secs(30))
+                .map(|_| Message::Reminder(reminder::ReminderMessage::Tick)),
+        );
+
         Subscription::batch(subscriptions)
     }
 
@@ -258,6 +266,32 @@ impl Application for AppModel {
                                 DialogPage::Calendar(CalendarModel::now()),
                             )));
                         }
+                        details::Output::OpenReminderDialog => {
+                            let (cal, hour, minute) =
+                                if let Some(ts) = self.details.task.reminder_date {
+                                    let zoned = ts.to_zoned(jiff::tz::TimeZone::system());
+                                    let date = zoned.date();
+                                    let h = zoned.hour() as u32;
+                                    let m = zoned.minute() as u32;
+                                    (CalendarModel::new(date, date), h, m)
+                                } else {
+                                    let now = jiff::Timestamp::now()
+                                        .to_zoned(jiff::tz::TimeZone::system());
+                                    let date = now.date();
+                                    (
+                                        CalendarModel::new(date, date),
+                                        now.hour() as u32,
+                                        now.minute() as u32,
+                                    )
+                                };
+                            return cosmic::task::message(Message::Dialog(DialogAction::Open(
+                                DialogPage::ReminderDateTime {
+                                    calendar: cal,
+                                    hour,
+                                    minute,
+                                },
+                            )));
+                        }
                         details::Output::RefreshTask(task) => {
                             return cosmic::task::message(Message::Content(
                                 content::Message::RefreshTask(task.clone()),
@@ -268,6 +302,26 @@ impl Application for AppModel {
             }
             Message::Trash(msg) => {
                 self.trash.update(msg);
+            }
+            Message::Reminder(msg) => {
+                use crate::services::reminder::ReminderMessage;
+                match msg {
+                    ReminderMessage::Tick => {
+                        let now = jiff::Timestamp::now();
+                        let window_start = now
+                            .checked_sub(jiff::SignedDuration::from_secs(30))
+                            .unwrap_or(now);
+                        let notified = reminder::check_and_notify(
+                            &self.store,
+                            now,
+                            window_start,
+                            &self.sent_reminders,
+                        );
+                        for key in notified {
+                            self.sent_reminders.insert(key);
+                        }
+                    }
+                }
             }
             Message::Favorites(msg) => {
                 if let Some(output) = self.favorites.update(msg) {

--- a/src/app/core/init.rs
+++ b/src/app/core/init.rs
@@ -42,6 +42,7 @@ impl AppModel {
             trash_entity: widget::segmented_button::Entity::default(),
             favorites: Favorites::new(flags.store.clone()),
             favorites_entity: widget::segmented_button::Entity::default(),
+            sent_reminders: std::collections::HashSet::new(),
         };
 
         let mut tasks = vec![cosmic::task::message(Message::Tasks(

--- a/src/app/core/message.rs
+++ b/src/app/core/message.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     config::AppConfig,
     pages::{content, details, favorites, trash},
+    services::reminder::ReminderMessage,
 };
 
 use super::ContextPage;
@@ -25,4 +26,5 @@ pub enum Message {
     UpdateConfig(AppConfig),
     Trash(trash::Message),
     Favorites(favorites::Message),
+    Reminder(ReminderMessage),
 }

--- a/src/app/core/model.rs
+++ b/src/app/core/model.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use cosmic::{
     app::Core,
@@ -6,6 +6,8 @@ use cosmic::{
     iced::keyboard::Modifiers,
     widget::{about::About, menu::key_bind::KeyBind, nav_bar},
 };
+
+use uuid::Uuid;
 
 use crate::{
     app::{dialogs::DialogPage, ui::MenuAction},
@@ -53,4 +55,7 @@ pub struct AppModel {
     pub(crate) favorites: Favorites,
     /// The nav bar entity for the favorites item.
     pub(crate) favorites_entity: nav_bar::Id,
+    /// Tracks (task_id, reminder_unix_second) pairs that have already had a
+    /// desktop notification sent, so we never fire the same reminder twice.
+    pub(crate) sent_reminders: HashSet<(Uuid, i64)>,
 }

--- a/src/app/dialogs/dialog.rs
+++ b/src/app/dialogs/dialog.rs
@@ -27,6 +27,11 @@ pub enum DialogPage {
     DeleteList(Option<segmented_button::Entity>, String),
     Calendar(CalendarModel),
     Export(String),
+    ReminderDateTime {
+        calendar: CalendarModel,
+        hour: u32,
+        minute: u32,
+    },
 }
 
 pub fn get_all_icon_handles(size: u16) -> Vec<(String, widget::icon::Handle)> {
@@ -234,6 +239,125 @@ impl DialogPage {
                     );
 
                 dialog
+            }
+            DialogPage::ReminderDateTime {
+                calendar,
+                hour,
+                minute,
+            } => {
+                let hour = *hour;
+                let minute = *minute;
+
+                let hour_col = widget::column::with_children(vec![
+                    widget::text::body(fl!("hour")).into(),
+                    widget::row::with_children(vec![
+                        widget::button::text("<")
+                            .on_press(Message::Dialog(DialogAction::Update(
+                                DialogPage::ReminderDateTime {
+                                    calendar: calendar.clone(),
+                                    hour: hour.saturating_sub(1),
+                                    minute,
+                                },
+                            )))
+                            .into(),
+                        widget::text::body(format!("{:02}", hour)).into(),
+                        widget::button::text(">")
+                            .on_press(Message::Dialog(DialogAction::Update(
+                                DialogPage::ReminderDateTime {
+                                    calendar: calendar.clone(),
+                                    hour: (hour + 1).min(23),
+                                    minute,
+                                },
+                            )))
+                            .into(),
+                    ])
+                    .align_y(cosmic::iced::Alignment::Center)
+                    .spacing(spacing.space_xs)
+                    .into(),
+                ])
+                .align_x(cosmic::iced::alignment::Horizontal::Center)
+                .spacing(spacing.space_xxs);
+
+                let minute_col = widget::column::with_children(vec![
+                    widget::text::body(fl!("minute")).into(),
+                    widget::row::with_children(vec![
+                        widget::button::text("<")
+                            .on_press(Message::Dialog(DialogAction::Update(
+                                DialogPage::ReminderDateTime {
+                                    calendar: calendar.clone(),
+                                    hour,
+                                    minute: minute.saturating_sub(1),
+                                },
+                            )))
+                            .into(),
+                        widget::text::body(format!("{:02}", minute)).into(),
+                        widget::button::text(">")
+                            .on_press(Message::Dialog(DialogAction::Update(
+                                DialogPage::ReminderDateTime {
+                                    calendar: calendar.clone(),
+                                    hour,
+                                    minute: (minute + 1).min(59),
+                                },
+                            )))
+                            .into(),
+                    ])
+                    .align_y(cosmic::iced::Alignment::Center)
+                    .spacing(spacing.space_xs)
+                    .into(),
+                ])
+                .align_x(cosmic::iced::alignment::Horizontal::Center)
+                .spacing(spacing.space_xxs);
+
+                let time_row = widget::container(
+                    widget::row::with_children(vec![hour_col.into(), minute_col.into()])
+                        .align_y(cosmic::iced::Alignment::Center)
+                        .spacing(spacing.space_l),
+                )
+                .width(Length::Fill)
+                .align_x(Horizontal::Center);
+
+                widget::dialog()
+                    .title(fl!("select-date-time"))
+                    .primary_action(
+                        widget::button::suggested(fl!("ok"))
+                            .on_press_maybe(Some(Message::Dialog(DialogAction::Complete))),
+                    )
+                    .secondary_action(
+                        widget::button::standard(fl!("cancel"))
+                            .on_press(Message::Dialog(DialogAction::Close)),
+                    )
+                    .control(
+                        widget::column::with_children(vec![
+                            widget::container(widget::calendar(
+                                calendar,
+                                {
+                                    let hour = hour;
+                                    let minute = minute;
+                                    move |selected_date| {
+                                        Message::Dialog(DialogAction::Update(
+                                            DialogPage::ReminderDateTime {
+                                                calendar: CalendarModel::new(
+                                                    selected_date,
+                                                    selected_date,
+                                                ),
+                                                hour,
+                                                minute,
+                                            },
+                                        ))
+                                    }
+                                },
+                                || Message::Dialog(DialogAction::None),
+                                || Message::Dialog(DialogAction::None),
+                                jiff::civil::Weekday::Monday,
+                            ))
+                            .width(Length::Fill)
+                            .align_x(Horizontal::Center)
+                            .align_y(Vertical::Center)
+                            .into(),
+                            time_row.into(),
+                        ])
+                        .spacing(spacing.space_s),
+                    )
             }
         }
     }

--- a/src/app/dialogs/update.rs
+++ b/src/app/dialogs/update.rs
@@ -131,6 +131,32 @@ impl AppModel {
                             self.details
                                 .update(details::Message::SetDueDate(date.selected));
                         }
+                        DialogPage::ReminderDateTime {
+                            calendar,
+                            hour,
+                            minute,
+                        } => {
+                            use jiff::civil::{DateTime, Time};
+                            let date = calendar.selected;
+                            match Time::new(hour as i8, minute as i8, 0, 0) {
+                                Ok(time) => {
+                                    let dt = DateTime::from_parts(date, time);
+                                    match dt.to_zoned(jiff::tz::TimeZone::system()) {
+                                        Ok(zoned) => {
+                                            self.details.update(details::Message::SetReminder(
+                                                zoned.timestamp(),
+                                            ));
+                                        }
+                                        Err(err) => tracing::error!(
+                                            "reminder: failed to build timestamp: {err}"
+                                        ),
+                                    }
+                                }
+                                Err(err) => {
+                                    tracing::error!("reminder: invalid time: {err}")
+                                }
+                            }
+                        }
                         DialogPage::Export(content) => {
                             let Ok(mut clipboard) = ClipboardContext::new() else {
                                 tracing::error!("Clipboard is not available");

--- a/src/pages/details.rs
+++ b/src/pages/details.rs
@@ -38,10 +38,14 @@ pub enum Message {
     Delete,
     OpenCalendarDialog,
     SetDueDate(Date),
+    OpenReminderDialog,
+    SetReminder(jiff::Timestamp),
+    ClearReminder,
 }
 
 pub enum Output {
     OpenCalendarDialog,
+    OpenReminderDialog,
     RefreshTask(model::Task),
     /// Request deletion of the currently displayed task; routed to content's
     /// undo-timer flow by the app model.
@@ -115,6 +119,15 @@ impl Details {
             Message::OpenCalendarDialog => {
                 return Some(Output::OpenCalendarDialog);
             }
+            Message::OpenReminderDialog => {
+                return Some(Output::OpenReminderDialog);
+            }
+            Message::SetReminder(ts) => {
+                self.task.reminder_date = Some(ts);
+            }
+            Message::ClearReminder => {
+                self.task.reminder_date = None;
+            }
             Message::SetDueDate(date) => {
                 self.task.due_date = Some(date);
             }
@@ -181,6 +194,26 @@ impl Details {
                         .on_press(Message::OpenCalendarDialog),
                     ),
                 )
+                .add({
+                    let reminder_label = if let Some(ts) = &self.task.reminder_date {
+                        model::Task::format_timestamp(ts)
+                    } else {
+                        fl!("set-reminder")
+                    };
+                    let mut reminder_row =
+                        widget::row::with_children(vec![widget::button::text(reminder_label)
+                            .on_press(Message::OpenReminderDialog)
+                            .into()]);
+                    if self.task.reminder_date.is_some() {
+                        reminder_row = reminder_row.push(
+                            widget::button::icon(
+                                widget::icon::from_name("edit-clear-symbolic").size(14),
+                            )
+                            .on_press(Message::ClearReminder),
+                        );
+                    }
+                    widget::settings::item::builder(fl!("reminder")).control(reminder_row)
+                })
                 .add(
                     widget::column::with_children(vec![
                         widget::text::body(fl!("notes")).into(),

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,1 +1,2 @@
+pub mod reminder;
 pub mod store;

--- a/src/services/reminder.rs
+++ b/src/services/reminder.rs
@@ -1,0 +1,85 @@
+use std::collections::HashSet;
+
+use jiff::Timestamp;
+use notify_rust::Timeout;
+use uuid::Uuid;
+
+use crate::services::store::Store;
+
+/// Messages emitted by the reminder subscription.
+#[derive(Debug, Clone)]
+pub enum ReminderMessage {
+    /// A timer tick: check all tasks for due reminders.
+    Tick,
+}
+
+/// Scan every task across all lists and fire a desktop notification for each
+/// one whose `reminder_date` falls within `[window_start, now]`.  Returns the
+/// IDs of tasks for which a notification was successfully sent so the caller
+/// can record them in `sent_reminders` and avoid duplicates.
+pub fn check_and_notify(
+    store: &Store,
+    now: Timestamp,
+    window_start: Timestamp,
+    sent: &HashSet<(Uuid, i64)>,
+) -> Vec<(Uuid, i64)> {
+    let mut notified = Vec::new();
+
+    let lists = match store.lists().load_all() {
+        Ok(lists) => lists,
+        Err(err) => {
+            tracing::error!("reminder: failed to load lists: {err}");
+            return notified;
+        }
+    };
+
+    for list in lists {
+        let tasks = match store.tasks(list.id).load_all() {
+            Ok(tasks) => tasks,
+            Err(err) => {
+                tracing::error!("reminder: failed to load tasks for list {}: {err}", list.id);
+                continue;
+            }
+        };
+
+        for task in tasks {
+            let Some(reminder) = task.reminder_date else {
+                continue;
+            };
+
+            let key = (task.id, reminder.as_second());
+
+            // Skip tasks whose reminder has already been sent or is outside
+            // the current window.
+            if sent.contains(&key) || reminder < window_start || reminder > now {
+                continue;
+            }
+
+            let result = notify_rust::Notification::new()
+                .summary("Task Reminder")
+                .body(&task.title)
+                .icon("dev.edfloreshz.Tasks")
+                .timeout(Timeout::Milliseconds(5000))
+                .show();
+
+            match result {
+                Ok(_) => {
+                    tracing::info!(
+                        "reminder: sent notification for task \"{}\" ({})",
+                        task.title,
+                        task.id
+                    );
+                    notified.push(key);
+                }
+                Err(err) => {
+                    tracing::error!(
+                        "reminder: failed to send notification for task \"{}\": {err}",
+                        task.title
+                    );
+                }
+            }
+        }
+    }
+
+    notified
+}


### PR DESCRIPTION
This pull request adds a complete reminder system to the application, allowing users to set reminders for tasks with date and time selection, and receive desktop notifications when reminders are due. The implementation includes UI changes for setting and clearing reminders, and backend logic for tracking and firing notifications.

- Added `notify-rust` dependency.
- Implemented `services/reminder.rs` to scan tasks and show notifications.
- Added a `ReminderDateTime` dialog.

> [!NOTE]
> Closing the app will not allow reminders to be sent, we need to move this functionality to a daemon or an applet at some point.

Closes #23 