### PR TITLE
feat: preserve last selected list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ target/
 /flatpak_build
 **/.venv
 **/.DS_Store
+.claude/

--- a/src/app.rs
+++ b/src/app.rs
@@ -184,6 +184,9 @@ impl Application for AppModel {
         let location_opt = self.nav.data::<List>(entity);
 
         if let Some(list) = location_opt {
+            if let Err(err) = self.config.set_last_list_id(&self.handler, Some(list.id)) {
+                tracing::error!("{err}");
+            }
             let message = Message::Content(content::Message::SetList(Some(list.clone())));
             let window_title = format!("{} - {}", list.name, fl!("tasks"));
             if let Some(window_id) = self.core.main_window_id() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use cosmic::{
     theme,
 };
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 pub const CONFIG_VERSION: u64 = 1;
 
@@ -14,6 +15,7 @@ pub struct AppConfig {
     pub show_favorites: bool,
     pub show_trash: bool,
     pub sort_by: SortBy,
+    pub last_list_id: Option<Uuid>,
 }
 
 impl Default for AppConfig {
@@ -24,6 +26,7 @@ impl Default for AppConfig {
             show_favorites: true,
             show_trash: true,
             sort_by: SortBy::default(),
+            last_list_id: None,
         }
     }
 }

--- a/src/shared/navigation/nav/update.rs
+++ b/src/shared/navigation/nav/update.rs
@@ -30,7 +30,16 @@ impl AppModel {
                     self.create_nav_item(&list);
                 }
                 self.reposition_special_items();
-                let Some(entity) = self.nav.iter().next() else {
+                let entity = self
+                    .config
+                    .last_list_id
+                    .and_then(|id| {
+                        self.nav
+                            .iter()
+                            .find(|e| self.nav.data::<List>(*e).is_some_and(|l| l.id == id))
+                    })
+                    .or_else(|| self.nav.iter().next());
+                let Some(entity) = entity else {
                     return app::Task::none();
                 };
                 self.nav.activate(entity);


### PR DESCRIPTION
This PR introduces changes that enable users to save their last selected list and have it automatically selected when the app opens again.

Closes #131