### PR TITLE
fix: empty task inserts

### DIFF
--- a/src/features/lists/content.rs
+++ b/src/features/lists/content.rs
@@ -266,8 +266,9 @@ impl Content {
             }
             Message::TaskAdd => {
                 if let Some(list) = &self.selected_list {
-                    if !self.add_task_input.is_empty() {
-                        let task = Task::new(self.add_task_input.clone());
+                    let title = self.add_task_input.trim();
+                    if !title.is_empty() {
+                        let task = Task::new(title);
                         match self.store.tasks(list.id).save(&task) {
                             Ok(_) => {
                                 let id = self.tasks.insert(task);


### PR DESCRIPTION
This PR prevents inserting only spaces and trims task title before insertion.

Closes #113