### PR TITLE
feat(trash): icon reflects current state

### DIFF
--- a/i18n/en/tasks.ftl
+++ b/i18n/en/tasks.ftl
@@ -2,6 +2,7 @@ tasks = Tasks
 favorites = Favorites
 trash = Trash
 empty-trash = Empty trash
+empty-trash-confirm = All tasks in the trash will be permanently deleted. This action cannot be undone.
 no-favorites = No favorites
 no-favorites-suggestion = Mark tasks as favorites to see them here
 no-trash = Trash is empty

--- a/src/app.rs
+++ b/src/app.rs
@@ -271,13 +271,17 @@ impl Application for AppModel {
                             return app::Task::batch(tasks);
                         }
                         content::Output::TaskDeleted => {
+                            let mut tasks = vec![cosmic::task::message(Message::Trash(
+                                trash::trash::Message::Load,
+                            ))];
                             if self.core.window.show_context
                                 && self.context_page == ContextPage::TaskDetails
                             {
-                                return cosmic::task::message(Message::ToggleContextPage(
+                                tasks.push(cosmic::task::message(Message::ToggleContextPage(
                                     ContextPage::TaskDetails,
-                                ));
+                                )));
                             }
+                            return app::Task::batch(tasks);
                         }
                         content::Output::ToggleHideCompleted(list) => {
                             if let Some(data) = self.nav.active_data_mut::<List>() {
@@ -344,7 +348,13 @@ impl Application for AppModel {
                 }
             }
             Message::Trash(msg) => {
-                self.trash.update(msg);
+                let output = self.trash.update(msg);
+                self.refresh_trash_nav_icon();
+                if let Some(trash::trash::Output::EmptyTrashRequested) = output {
+                    return cosmic::task::message(Message::Dialog(DialogAction::Open(
+                        DialogPage::EmptyTrash,
+                    )));
+                }
             }
             Message::Reminder(msg) => {
                 use crate::features::reminders::reminder::ReminderMessage;

--- a/src/features/trash/nav.rs
+++ b/src/features/trash/nav.rs
@@ -1,17 +1,14 @@
-use cosmic::widget;
-
 use crate::{app::AppModel, fl};
 
 pub struct TrashMarker;
 
 impl AppModel {
     pub fn show_trash_nav_item(&mut self) {
-        let icon = widget::icon::from_name("user-trash-full-symbolic").size(16);
         self.trash_entity = self
             .nav
             .insert()
             .text(fl!("trash"))
-            .icon(icon)
+            .icon(self.trash.icon())
             .data(TrashMarker)
             .id();
         self.reposition_special_items();
@@ -20,5 +17,11 @@ impl AppModel {
     pub fn hide_trash_nav_item(&mut self) {
         self.nav.remove(self.trash_entity);
         self.reposition_special_items();
+    }
+
+    pub fn refresh_trash_nav_icon(&mut self) {
+        if self.nav.data::<TrashMarker>(self.trash_entity).is_some() {
+            self.nav.icon_set(self.trash_entity, self.trash.icon().icon());
+        }
     }
 }

--- a/src/features/trash/trash.rs
+++ b/src/features/trash/trash.rs
@@ -4,7 +4,9 @@ use cosmic::{
         alignment::{Horizontal, Vertical},
         Alignment, Length,
     },
-    theme, widget, Apply, Element,
+    theme,
+    widget::{self, icon::Named},
+    Apply, Element,
 };
 use uuid::Uuid;
 
@@ -35,7 +37,12 @@ pub enum Message {
     TaskDeletionTick,
     TaskDeletionUndo,
     EmptyTrash,
+    EmptyTrashConfirmed,
     RestoreAll,
+}
+
+pub enum Output {
+    EmptyTrashRequested,
 }
 
 impl Trash {
@@ -52,7 +59,7 @@ impl Trash {
         self.pending_deletion.is_some()
     }
 
-    pub fn update(&mut self, message: Message) {
+    pub fn update(&mut self, message: Message) -> Option<Output> {
         match message {
             Message::Load => {
                 let tasks = self.store.trash().load_all().unwrap_or_else(|e| {
@@ -124,20 +131,17 @@ impl Trash {
                 }
             }
             Message::EmptyTrash => {
-                if let Some(existing) = self.pending_deletion.take() {
-                    for t in existing.tasks {
-                        if let Err(e) = self.store.trash().delete(t.task.id) {
-                            tracing::error!("Error committing previous permanent deletion: {e}");
-                        }
-                    }
+                return Some(Output::EmptyTrashRequested);
+            }
+            Message::EmptyTrashConfirmed => {
+                let mut tasks = std::mem::take(&mut self.tasks);
+                if let Some(pending) = self.pending_deletion.take() {
+                    tasks.extend(pending.tasks);
                 }
-
-                if !self.tasks.is_empty() {
-                    let all_tasks = std::mem::take(&mut self.tasks);
-                    self.pending_deletion = Some(PendingDeletion {
-                        tasks: all_tasks,
-                        seconds_remaining: 5,
-                    });
+                for t in tasks {
+                    if let Err(e) = self.store.trash().delete(t.task.id) {
+                        tracing::error!("Error emptying trash: {e}");
+                    }
                 }
             }
             Message::RestoreAll => {
@@ -157,6 +161,8 @@ impl Trash {
                 }
             }
         }
+
+        None
     }
 
     pub fn view(&self) -> Element<'_, Message> {
@@ -311,5 +317,17 @@ impl Trash {
         .height(Length::Fill)
         .width(Length::Fill)
         .into()
+    }
+
+    pub fn icon(&self) -> Named {
+        if self.is_empty() {
+            widget::icon::from_name("user-trash-symbolic").size(16)
+        } else {
+            widget::icon::from_name("user-trash-full-symbolic").size(16)
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tasks.is_empty() && self.pending_deletion.is_none()
     }
 }

--- a/src/shared/dialogs/dialog.rs
+++ b/src/shared/dialogs/dialog.rs
@@ -25,6 +25,7 @@ pub enum DialogPage {
     SetListIcon(Option<segmented_button::Entity>, String, String),
     RenameList(Option<segmented_button::Entity>, String),
     DeleteList(Option<segmented_button::Entity>, String),
+    EmptyTrash,
     Calendar(CalendarModel),
     Export(String),
     ReminderDateTime {
@@ -128,6 +129,17 @@ impl DialogPage {
                 .primary_action(
                     widget::button::suggested(fl!("ok"))
                         .on_press_maybe(Some(Message::Dialog(DialogAction::Complete))),
+                )
+                .secondary_action(
+                    widget::button::standard(fl!("cancel"))
+                        .on_press(Message::Dialog(DialogAction::Close)),
+                ),
+            DialogPage::EmptyTrash => widget::dialog()
+                .title(fl!("empty-trash"))
+                .body(fl!("empty-trash-confirm"))
+                .primary_action(
+                    widget::button::destructive(fl!("empty-trash"))
+                        .on_press(Message::Dialog(DialogAction::Complete)),
                 )
                 .secondary_action(
                     widget::button::standard(fl!("cancel"))

--- a/src/shared/dialogs/update.rs
+++ b/src/shared/dialogs/update.rs
@@ -125,6 +125,11 @@ impl AppModel {
                                 ));
                             }
                         }
+                        DialogPage::EmptyTrash => {
+                            return cosmic::task::message(Message::Trash(
+                                crate::features::trash::trash::Message::EmptyTrashConfirmed,
+                            ));
+                        }
                         DialogPage::Calendar(date) => {
                             self.details
                                 .update(details::Message::SetDueDate(date.selected));

--- a/src/shared/navigation/core/init.rs
+++ b/src/shared/navigation/core/init.rs
@@ -48,9 +48,12 @@ impl AppModel {
             sent_reminders: std::collections::HashSet::new(),
         };
 
-        let mut tasks = vec![cosmic::task::message(Message::Tasks(
-            TasksAction::FetchLists,
-        ))];
+        let mut tasks = vec![
+            cosmic::task::message(Message::Tasks(TasksAction::FetchLists)),
+            cosmic::task::message(Message::Trash(
+                crate::features::trash::trash::Message::Load,
+            )),
+        ];
 
         if let Some(id) = app.core.main_window_id() {
             tasks.push(app.set_window_title(fl!("tasks"), id));

--- a/src/shared/navigation/nav/update.rs
+++ b/src/shared/navigation/nav/update.rs
@@ -116,9 +116,11 @@ impl AppModel {
                 )));
             }
             NavMenuAction::TrashEmptyAll => {
-                return cosmic::task::message(Message::Trash(
-                    crate::features::trash::trash::Message::EmptyTrash,
-                ));
+                if !self.trash.is_empty() {
+                    return cosmic::task::message(Message::Dialog(DialogAction::Open(
+                        DialogPage::EmptyTrash,
+                    )));
+                }
             }
             NavMenuAction::TrashRestoreAll => {
                 return cosmic::task::message(Message::Trash(


### PR DESCRIPTION
This PR includes a change to update the trash icon to reflect its current state.

Closes #111