### PR TITLE
feat(trash): add undo toasts and restorable trashed lists

### DIFF
--- a/i18n/en/tasks.ftl
+++ b/i18n/en/tasks.ftl
@@ -9,11 +9,13 @@ no-trash = Trash is empty
 no-trash-suggestion = Deleted tasks will appear here
 restore = Restore
 restore-all = Restore all
+restore-list = Restore list
 delete-permanently = Delete permanently
 deleted-from = Deleted from "{ $list }"
 deleted-at = Deleted { $date }
 unknown-list = Unknown list
 trash-emptied = Trash emptied
+list = List
 about = About
 
 # Content
@@ -55,11 +57,17 @@ delete-list-confirm = Are you sure you want to delete "{ $name }"?
 # Deletion undo banner
 undo = Undo
 task-deleted = "{ $title }" deleted
+task-moved-to-trash = "{ $title }" moved to trash
+list-moved-to-trash = "{ $title }" moved to trash
 deletion-countdown = { $seconds }s
 
 # Delete Task Dialog
 delete-task = The selected task is about to be deleted
 delete-task-confirm = Are you sure you want to delete this task?
+delete-task-permanently = Delete task permanently
+delete-task-permanently-confirm = Are you sure you want to permanently delete "{ $title }"? This action cannot be undone.
+delete-list-permanently = Delete list permanently
+delete-list-permanently-confirm = Are you sure you want to permanently delete "{ $name }" and all of its tasks? This action cannot be undone.
 
 # Icon Dialog
 icon = Set icon

--- a/src/app.rs
+++ b/src/app.rs
@@ -270,10 +270,29 @@ impl Application for AppModel {
                             ];
                             return app::Task::batch(tasks);
                         }
-                        content::Output::TaskDeleted => {
-                            let mut tasks = vec![cosmic::task::message(Message::Trash(
-                                trash::trash::Message::Load,
-                            ))];
+                        content::Output::TaskDeleted {
+                            task_id,
+                            list_id,
+                            title,
+                        } => {
+                            let mut tasks = vec![
+                                cosmic::task::message(Message::Trash(
+                                    trash::trash::Message::Load,
+                                )),
+                                self.toasts
+                                    .push(
+                                        widget::Toast::new(fl!(
+                                            "task-moved-to-trash",
+                                            title = title.as_str()
+                                        ))
+                                        .action(fl!("undo"), move |_id| {
+                                            Message::Content(content::Message::RestoreTask(
+                                                task_id, list_id,
+                                            ))
+                                        }),
+                                    )
+                                    .map(cosmic::Action::App),
+                            ];
                             if self.core.window.show_context
                                 && self.context_page == ContextPage::TaskDetails
                             {
@@ -350,11 +369,48 @@ impl Application for AppModel {
             Message::Trash(msg) => {
                 let output = self.trash.update(msg);
                 self.refresh_trash_nav_icon();
-                if let Some(trash::trash::Output::EmptyTrashRequested) = output {
-                    return cosmic::task::message(Message::Dialog(DialogAction::Open(
-                        DialogPage::EmptyTrash,
-                    )));
+                match output {
+                    Some(trash::trash::Output::EmptyTrashRequested) => {
+                        return cosmic::task::message(Message::Dialog(DialogAction::Open(
+                            DialogPage::EmptyTrash,
+                        )));
+                    }
+                    Some(trash::trash::Output::DeleteTaskRequested(task_id, title)) => {
+                        return cosmic::task::message(Message::Dialog(DialogAction::Open(
+                            DialogPage::DeleteTaskPermanently(task_id, title),
+                        )));
+                    }
+                    Some(trash::trash::Output::RestoreListRequested(list_id)) => {
+                        return cosmic::task::message(Message::Tasks(
+                            crate::shared::navigation::nav::TasksAction::RestoreList(list_id),
+                        ));
+                    }
+                    Some(trash::trash::Output::DeleteListRequested(list_id, title)) => {
+                        return cosmic::task::message(Message::Dialog(DialogAction::Open(
+                            DialogPage::DeleteListPermanently(list_id, title),
+                        )));
+                    }
+                    Some(trash::trash::Output::RestoreTaskFromListRequested(list_id, task_id)) => {
+                        return cosmic::task::message(Message::Tasks(
+                            crate::shared::navigation::nav::TasksAction::RestoreTaskFromList(
+                                list_id, task_id,
+                            ),
+                        ));
+                    }
+                    Some(trash::trash::Output::DeleteTaskFromListRequested(
+                        list_id,
+                        task_id,
+                        title,
+                    )) => {
+                        return cosmic::task::message(Message::Dialog(DialogAction::Open(
+                            DialogPage::DeleteTaskFromListPermanently(list_id, task_id, title),
+                        )));
+                    }
+                    None => {}
                 }
+            }
+            Message::CloseToast(id) => {
+                self.toasts.remove(id);
             }
             Message::Reminder(msg) => {
                 use crate::features::reminders::reminder::ReminderMessage;
@@ -445,12 +501,14 @@ impl Application for AppModel {
     }
 
     fn view(&self) -> Element<'_, Self::Message> {
-        if self.nav.active_data::<TrashMarker>().is_some() {
+        let content = if self.nav.active_data::<TrashMarker>().is_some() {
             self.trash.view().map(Message::Trash)
         } else if self.nav.active_data::<FavoritesMarker>().is_some() {
             self.favorites.view().map(Message::Favorites)
         } else {
             self.content.view().map(Message::Content)
-        }
+        };
+
+        widget::toaster(&self.toasts, content)
     }
 }

--- a/src/features/lists/content.rs
+++ b/src/features/lists/content.rs
@@ -118,6 +118,7 @@ pub enum Message {
     RefreshTask(Task),
     Empty,
     OpenTaskDeletionDialog(DefaultKey),
+    RestoreTask(Uuid, Uuid),
 
     ToggleSearchBar,
     SearchQueryChanged(String),
@@ -136,7 +137,11 @@ pub enum Output {
     ToggleHideCompleted(List),
     Focus(widget::Id),
     OpenTaskDetails(DefaultKey, Uuid),
-    TaskDeleted,
+    TaskDeleted {
+        task_id: Uuid,
+        list_id: Uuid,
+        title: String,
+    },
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -380,7 +385,33 @@ impl Content {
                     if let Err(err) = self.store.tasks(list_id).delete(task.id) {
                         tracing::error!("Error removing task from list after trashing: {err}");
                     }
-                    output = Some(Output::TaskDeleted);
+                    output = Some(Output::TaskDeleted {
+                        task_id: task.id,
+                        list_id,
+                        title: task.title.clone(),
+                    });
+                }
+            }
+            Message::RestoreTask(task_id, list_id) => {
+                let trashed = self.store.trash().load_all().unwrap_or_else(|err| {
+                    tracing::error!("Failed to load trash for restore: {err}");
+                    Vec::new()
+                });
+                if let Some(trashed) = trashed.into_iter().find(|t| t.task.id == task_id) {
+                    if let Err(err) = self.store.tasks(trashed.original_list_id).save(&trashed.task)
+                    {
+                        tracing::error!("Error restoring task from trash: {err}");
+                    } else if let Err(err) = self.store.trash().delete(task_id) {
+                        tracing::error!("Error removing restored task from trash: {err}");
+                    } else if self
+                        .selected_list
+                        .as_ref()
+                        .is_some_and(|list| list.id == list_id)
+                    {
+                        if let Ok(tasks) = self.store.tasks(list_id).load_all() {
+                            self.update(Message::SetTasks(tasks));
+                        }
+                    }
                 }
             }
             Message::TaskComplete(id, complete) => {

--- a/src/features/lists/list.rs
+++ b/src/features/lists/list.rs
@@ -38,3 +38,23 @@ impl List {
         }
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrashedList {
+    pub list: List,
+    pub deleted_at: Timestamp,
+}
+
+impl TrashedList {
+    pub fn new(list: List) -> Self {
+        Self {
+            list,
+            deleted_at: Timestamp::now(),
+        }
+    }
+
+    pub fn deleted_at_local(&self) -> String {
+        let tz = jiff::tz::TimeZone::system();
+        self.deleted_at.to_zoned(tz).strftime("%m-%d-%Y %H:%M").to_string()
+    }
+}

--- a/src/features/trash/trash.rs
+++ b/src/features/trash/trash.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet};
+
 use cosmic::{
     cosmic_theme::Spacing,
     iced::{
@@ -11,7 +13,10 @@ use cosmic::{
 use uuid::Uuid;
 
 use crate::{
-    features::{lists::list::List, tasks::task::TrashedTask},
+    features::{
+        lists::list::{List, TrashedList},
+        tasks::task::{Task, TrashedTask},
+    },
     fl,
     shared::store::Store,
 };
@@ -24,16 +29,32 @@ struct PendingDeletion {
 pub struct Trash {
     pub tasks: Vec<TrashedTask>,
     pub lists: Vec<List>,
+    pub trashed_lists: Vec<TrashedList>,
+    pub trashed_list_tasks: HashMap<Uuid, Vec<Task>>,
     store: Store,
     pending_deletion: Option<PendingDeletion>,
+    collapsed_sections: HashSet<Uuid>,
 }
 
 #[derive(Debug, Clone)]
 pub enum Message {
     Load,
-    Loaded(Vec<TrashedTask>, Vec<List>),
+    Loaded(
+        Vec<TrashedTask>,
+        Vec<List>,
+        Vec<TrashedList>,
+        HashMap<Uuid, Vec<Task>>,
+    ),
+    ToggleSection(Uuid),
     RestoreTask(Uuid),
+    RequestDeleteTask(Uuid),
     DeleteTask(Uuid),
+    RequestRestoreList(Uuid),
+    RequestDeleteList(Uuid),
+    DeleteListConfirmed(Uuid),
+    RequestRestoreTaskFromList(Uuid, Uuid),
+    RequestDeleteTaskFromList(Uuid, Uuid),
+    DeleteTaskFromListConfirmed(Uuid, Uuid),
     TaskDeletionTick,
     TaskDeletionUndo,
     EmptyTrash,
@@ -43,6 +64,11 @@ pub enum Message {
 
 pub enum Output {
     EmptyTrashRequested,
+    DeleteTaskRequested(Uuid, String),
+    RestoreListRequested(Uuid),
+    DeleteListRequested(Uuid, String),
+    RestoreTaskFromListRequested(Uuid, Uuid),
+    DeleteTaskFromListRequested(Uuid, Uuid, String),
 }
 
 impl Trash {
@@ -50,8 +76,11 @@ impl Trash {
         Self {
             tasks: Vec::new(),
             lists: Vec::new(),
+            trashed_lists: Vec::new(),
+            trashed_list_tasks: HashMap::new(),
             store,
             pending_deletion: None,
+            collapsed_sections: HashSet::new(),
         }
     }
 
@@ -70,11 +99,39 @@ impl Trash {
                     tracing::error!("Failed to load lists for trash: {e}");
                     vec![]
                 });
-                return self.update(Message::Loaded(tasks, lists));
+                let trashed_lists = self.store.trash().load_all_lists().unwrap_or_else(|e| {
+                    tracing::error!("Failed to load trashed lists: {e}");
+                    vec![]
+                });
+                let mut trashed_list_tasks = HashMap::new();
+                for trashed_list in &trashed_lists {
+                    let list_tasks = self
+                        .store
+                        .trash()
+                        .load_trashed_list_tasks(trashed_list.list.id)
+                        .unwrap_or_else(|e| {
+                            tracing::error!("Failed to load tasks for trashed list: {e}");
+                            vec![]
+                        });
+                    trashed_list_tasks.insert(trashed_list.list.id, list_tasks);
+                }
+                return self.update(Message::Loaded(
+                    tasks,
+                    lists,
+                    trashed_lists,
+                    trashed_list_tasks,
+                ));
             }
-            Message::Loaded(tasks, lists) => {
+            Message::Loaded(tasks, lists, trashed_lists, trashed_list_tasks) => {
                 self.tasks = tasks;
                 self.lists = lists;
+                self.trashed_lists = trashed_lists;
+                self.trashed_list_tasks = trashed_list_tasks;
+            }
+            Message::ToggleSection(list_id) => {
+                if !self.collapsed_sections.remove(&list_id) {
+                    self.collapsed_sections.insert(list_id);
+                }
             }
             Message::RestoreTask(task_id) => {
                 if let Some(pos) = self.tasks.iter().position(|t| t.task.id == task_id) {
@@ -88,6 +145,14 @@ impl Trash {
                     } else if let Err(e) = self.store.trash().delete(task_id) {
                         tracing::error!("Failed to remove task from trash after restore: {e}");
                     }
+                }
+            }
+            Message::RequestDeleteTask(task_id) => {
+                if let Some(trashed) = self.tasks.iter().find(|t| t.task.id == task_id) {
+                    return Some(Output::DeleteTaskRequested(
+                        task_id,
+                        trashed.task.title.clone(),
+                    ));
                 }
             }
             Message::DeleteTask(task_id) => {
@@ -105,6 +170,52 @@ impl Trash {
                         tasks: vec![trashed],
                         seconds_remaining: 5,
                     });
+                }
+            }
+            Message::RequestRestoreList(list_id) => {
+                return Some(Output::RestoreListRequested(list_id));
+            }
+            Message::RequestDeleteList(list_id) => {
+                if let Some(trashed) = self.trashed_lists.iter().find(|t| t.list.id == list_id) {
+                    return Some(Output::DeleteListRequested(
+                        list_id,
+                        trashed.list.name.clone(),
+                    ));
+                }
+            }
+            Message::DeleteListConfirmed(list_id) => {
+                if let Err(e) = self.store.trash().delete_list(list_id) {
+                    tracing::error!("Error permanently deleting list from trash: {e}");
+                }
+                self.trashed_lists.retain(|t| t.list.id != list_id);
+                self.trashed_list_tasks.remove(&list_id);
+            }
+            Message::RequestRestoreTaskFromList(list_id, task_id) => {
+                return Some(Output::RestoreTaskFromListRequested(list_id, task_id));
+            }
+            Message::RequestDeleteTaskFromList(list_id, task_id) => {
+                if let Some(task) = self
+                    .trashed_list_tasks
+                    .get(&list_id)
+                    .and_then(|tasks| tasks.iter().find(|t| t.id == task_id))
+                {
+                    return Some(Output::DeleteTaskFromListRequested(
+                        list_id,
+                        task_id,
+                        task.title.clone(),
+                    ));
+                }
+            }
+            Message::DeleteTaskFromListConfirmed(list_id, task_id) => {
+                if let Err(e) = self.store.trash().delete_task_from_list(list_id, task_id) {
+                    tracing::error!("Error permanently deleting task from trashed list: {e}");
+                }
+                if let Some(tasks) = self.trashed_list_tasks.get_mut(&list_id) {
+                    tasks.retain(|t| t.id != task_id);
+                    if tasks.is_empty() {
+                        self.trashed_list_tasks.remove(&list_id);
+                        self.trashed_lists.retain(|t| t.list.id != list_id);
+                    }
                 }
             }
             Message::TaskDeletionTick => {
@@ -143,6 +254,12 @@ impl Trash {
                         tracing::error!("Error emptying trash: {e}");
                     }
                 }
+                for trashed in std::mem::take(&mut self.trashed_lists) {
+                    if let Err(e) = self.store.trash().delete_list(trashed.list.id) {
+                        tracing::error!("Error emptying trashed list: {e}");
+                    }
+                }
+                self.trashed_list_tasks.clear();
             }
             Message::RestoreAll => {
                 self.pending_deletion.take();
@@ -168,16 +285,14 @@ impl Trash {
     pub fn view(&self) -> Element<'_, Message> {
         let spacing = theme::active().cosmic().spacing;
 
-        if self.tasks.is_empty() && self.pending_deletion.is_none() {
+        if self.is_empty() {
             return self.empty_view();
         }
 
         let header = self.header_view();
 
-        let task_rows: Vec<Element<'_, Message>> =
-            self.tasks.iter().map(|t| self.task_row(t)).collect();
-
-        let list = widget::column::with_children(task_rows).spacing(spacing.space_xxs);
+        let sections = self.list_sections();
+        let list = widget::column::with_children(sections).spacing(spacing.space_xxs);
 
         let mut content = widget::column::with_capacity(3)
             .push(header)
@@ -226,50 +341,193 @@ impl Trash {
             .into()
     }
 
-    fn task_row<'a>(&'a self, trashed: &'a TrashedTask) -> Element<'a, Message> {
+    fn list_sections(&self) -> Vec<Element<'_, Message>> {
+        let mut list_ids: Vec<Uuid> = Vec::new();
+        for t in &self.tasks {
+            if !list_ids.contains(&t.original_list_id) {
+                list_ids.push(t.original_list_id);
+            }
+        }
+        for t in &self.trashed_lists {
+            if !list_ids.contains(&t.list.id) {
+                list_ids.push(t.list.id);
+            }
+        }
+
+        let mut sections: Vec<(String, Element<'_, Message>)> = list_ids
+            .into_iter()
+            .map(|list_id| {
+                let trashed_list = self.trashed_lists.iter().find(|t| t.list.id == list_id);
+                let name = trashed_list
+                    .map(|t| t.list.name.clone())
+                    .or_else(|| {
+                        self.lists
+                            .iter()
+                            .find(|l| l.id == list_id)
+                            .map(|l| l.name.clone())
+                    })
+                    .unwrap_or_else(|| fl!("unknown-list"));
+
+                let individually: Vec<&TrashedTask> = self
+                    .tasks
+                    .iter()
+                    .filter(|t| t.original_list_id == list_id)
+                    .collect();
+                let from_list: Vec<&Task> = self
+                    .trashed_list_tasks
+                    .get(&list_id)
+                    .map(|tasks| tasks.iter().collect())
+                    .unwrap_or_default();
+
+                let section =
+                    self.list_section(list_id, name.clone(), trashed_list, individually, from_list);
+                (name, section)
+            })
+            .collect();
+
+        sections.sort_by(|a, b| a.0.cmp(&b.0));
+        sections.into_iter().map(|(_, section)| section).collect()
+    }
+
+    fn list_section<'a>(
+        &'a self,
+        list_id: Uuid,
+        name: String,
+        trashed_list: Option<&'a TrashedList>,
+        individually: Vec<&'a TrashedTask>,
+        from_list: Vec<&'a Task>,
+    ) -> Element<'a, Message> {
+        let spacing = theme::active().cosmic().spacing;
+        let collapsed = self.collapsed_sections.contains(&list_id);
+        let count = individually.len() + from_list.len();
+
+        let mut list = widget::list_column()
+            .list_item_padding(0)
+            .add(self.list_section_header(list_id, name, trashed_list, count, collapsed, &spacing));
+
+        if !collapsed {
+            for trashed in individually {
+                list = list.add(self.task_row(
+                    trashed.task.title.as_str(),
+                    Some(trashed.deleted_at_local()),
+                    Message::RestoreTask(trashed.task.id),
+                    Message::RequestDeleteTask(trashed.task.id),
+                ));
+            }
+            for task in from_list {
+                list = list.add(self.task_row(
+                    task.title.as_str(),
+                    None,
+                    Message::RequestRestoreTaskFromList(list_id, task.id),
+                    Message::RequestDeleteTaskFromList(list_id, task.id),
+                ));
+            }
+        }
+
+        widget::container(list)
+            .class(cosmic::style::Container::List)
+            .into()
+    }
+
+    fn list_section_header<'a>(
+        &'a self,
+        list_id: Uuid,
+        name: String,
+        trashed_list: Option<&'a TrashedList>,
+        count: usize,
+        collapsed: bool,
+        spacing: &Spacing,
+    ) -> Element<'a, Message> {
+        let chevron = if collapsed {
+            "go-down-symbolic"
+        } else {
+            "go-up-symbolic"
+        };
+
+        let badge = widget::container(widget::text(count.to_string()))
+            .class(theme::Container::Tooltip)
+            .padding([spacing.space_xxxs, spacing.space_xs]);
+
+        let mut title_children: Vec<Element<'a, Message>> =
+            vec![widget::text::heading(name).into()];
+        if let Some(trashed_list) = trashed_list {
+            let deleted_at = trashed_list.deleted_at_local();
+            title_children
+                .push(widget::text::caption(fl!("deleted-at", date = deleted_at.as_str())).into());
+        }
+        let title_col = widget::column::with_children(title_children).width(Length::Fill);
+
+        let mut row = widget::row::with_capacity(5)
+            .align_y(Alignment::Center)
+            .spacing(spacing.space_s)
+            .padding([spacing.space_xxs, spacing.space_s])
+            .push(title_col)
+            .push(badge);
+
+        let list_is_trashed = trashed_list.is_some() && !self.lists.iter().any(|l| l.id == list_id);
+
+        if list_is_trashed {
+            row = row
+                .push(
+                    widget::button::icon(widget::icon::from_name("edit-undo"))
+                        .tooltip(fl!("restore-list"))
+                        .class(theme::Button::Standard)
+                        .on_press(Message::RequestRestoreList(list_id)),
+                )
+                .push(
+                    widget::button::icon(widget::icon::from_name("edit-delete"))
+                        .tooltip(fl!("delete-permanently"))
+                        .class(theme::Button::Destructive)
+                        .on_press(Message::RequestDeleteList(list_id)),
+                );
+        }
+
+        row = row.push(
+            widget::button::icon(widget::icon::from_name(chevron).size(16))
+                .on_press(Message::ToggleSection(list_id)),
+        );
+
+        row.into()
+    }
+
+    fn task_row<'a>(
+        &'a self,
+        title: &'a str,
+        deleted_at: Option<String>,
+        restore_message: Message,
+        delete_message: Message,
+    ) -> Element<'a, Message> {
         let spacing = theme::active().cosmic().spacing;
 
-        let list_name = self
-            .lists
-            .iter()
-            .find(|l| l.id == trashed.original_list_id)
-            .map(|l| l.name.clone())
-            .unwrap_or_else(|| fl!("unknown-list"));
-
-        let title = widget::text::body(trashed.task.title.as_str()).width(Length::Fill);
-
-        let subtitle = widget::text::caption(fl!("deleted-from", list = list_name.as_str()))
+        let mut text_col = widget::column::with_capacity(2)
+            .push(widget::text::body(title))
             .width(Length::Fill);
+        if let Some(deleted_at) = deleted_at {
+            text_col = text_col.push(widget::text::caption(fl!(
+                "deleted-at",
+                date = deleted_at.as_str()
+            )));
+        }
 
-        let task_id = trashed.task.id;
-        let deleted_at = trashed.deleted_at_local();
+        let restore_button = widget::button::icon(widget::icon::from_name("edit-undo"))
+            .tooltip(fl!("restore"))
+            .class(theme::Button::Standard)
+            .on_press(restore_message);
 
-        let date = widget::text::caption(fl!("deleted-at", date = deleted_at.as_str()));
-
-        let restore_button =
-            widget::button::standard(fl!("restore")).on_press(Message::RestoreTask(task_id));
-
-        let delete_button = widget::button::destructive(fl!("delete-permanently"))
-            .on_press(Message::DeleteTask(task_id));
-
-        let text_col = widget::column::with_capacity(3)
-            .push(title)
-            .push(subtitle)
-            .push(date)
-            .width(Length::Fill);
+        let delete_button = widget::button::icon(widget::icon::from_name("edit-delete"))
+            .tooltip(fl!("delete-permanently"))
+            .class(theme::Button::Destructive)
+            .on_press(delete_message);
 
         let row = widget::row::with_capacity(3)
             .align_y(Alignment::Center)
             .spacing(spacing.space_s)
-            .padding([spacing.space_xxxs, spacing.space_xs])
+            .padding([spacing.space_xxs, spacing.space_xs])
             .push(text_col)
             .push(restore_button)
             .push(delete_button);
 
-        widget::container(row)
-            .class(cosmic::style::Container::ContextDrawer { transparent: false })
-            .width(Length::Fill)
-            .into()
+        widget::list_column().list_item_padding(0).add(row).into()
     }
 
     fn deletion_banner<'a>(
@@ -328,6 +586,6 @@ impl Trash {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.tasks.is_empty() && self.pending_deletion.is_none()
+        self.tasks.is_empty() && self.trashed_lists.is_empty() && self.pending_deletion.is_none()
     }
 }

--- a/src/shared/dialogs/dialog.rs
+++ b/src/shared/dialogs/dialog.rs
@@ -25,6 +25,9 @@ pub enum DialogPage {
     SetListIcon(Option<segmented_button::Entity>, String, String),
     RenameList(Option<segmented_button::Entity>, String),
     DeleteList(Option<segmented_button::Entity>, String),
+    DeleteTaskPermanently(uuid::Uuid, String),
+    DeleteTaskFromListPermanently(uuid::Uuid, uuid::Uuid, String),
+    DeleteListPermanently(uuid::Uuid, String),
     EmptyTrash,
     Calendar(CalendarModel),
     Export(String),
@@ -129,6 +132,39 @@ impl DialogPage {
                 .primary_action(
                     widget::button::suggested(fl!("ok"))
                         .on_press_maybe(Some(Message::Dialog(DialogAction::Complete))),
+                )
+                .secondary_action(
+                    widget::button::standard(fl!("cancel"))
+                        .on_press(Message::Dialog(DialogAction::Close)),
+                ),
+            DialogPage::DeleteTaskPermanently(_, title) => widget::dialog()
+                .title(fl!("delete-task-permanently"))
+                .body(fl!("delete-task-permanently-confirm", title = title.as_str()))
+                .primary_action(
+                    widget::button::destructive(fl!("delete-permanently"))
+                        .on_press(Message::Dialog(DialogAction::Complete)),
+                )
+                .secondary_action(
+                    widget::button::standard(fl!("cancel"))
+                        .on_press(Message::Dialog(DialogAction::Close)),
+                ),
+            DialogPage::DeleteTaskFromListPermanently(_, _, title) => widget::dialog()
+                .title(fl!("delete-task-permanently"))
+                .body(fl!("delete-task-permanently-confirm", title = title.as_str()))
+                .primary_action(
+                    widget::button::destructive(fl!("delete-permanently"))
+                        .on_press(Message::Dialog(DialogAction::Complete)),
+                )
+                .secondary_action(
+                    widget::button::standard(fl!("cancel"))
+                        .on_press(Message::Dialog(DialogAction::Close)),
+                ),
+            DialogPage::DeleteListPermanently(_, name) => widget::dialog()
+                .title(fl!("delete-list-permanently"))
+                .body(fl!("delete-list-permanently-confirm", name = name.as_str()))
+                .primary_action(
+                    widget::button::destructive(fl!("delete-permanently"))
+                        .on_press(Message::Dialog(DialogAction::Complete)),
                 )
                 .secondary_action(
                     widget::button::standard(fl!("cancel"))

--- a/src/shared/dialogs/update.rs
+++ b/src/shared/dialogs/update.rs
@@ -125,6 +125,25 @@ impl AppModel {
                                 ));
                             }
                         }
+                        DialogPage::DeleteTaskPermanently(task_id, _) => {
+                            return cosmic::task::message(Message::Trash(
+                                crate::features::trash::trash::Message::DeleteTask(task_id),
+                            ));
+                        }
+                        DialogPage::DeleteTaskFromListPermanently(list_id, task_id, _) => {
+                            return cosmic::task::message(Message::Trash(
+                                crate::features::trash::trash::Message::DeleteTaskFromListConfirmed(
+                                    list_id, task_id,
+                                ),
+                            ));
+                        }
+                        DialogPage::DeleteListPermanently(list_id, _) => {
+                            return cosmic::task::message(Message::Trash(
+                                crate::features::trash::trash::Message::DeleteListConfirmed(
+                                    list_id,
+                                ),
+                            ));
+                        }
                         DialogPage::EmptyTrash => {
                             return cosmic::task::message(Message::Trash(
                                 crate::features::trash::trash::Message::EmptyTrashConfirmed,

--- a/src/shared/navigation/core/init.rs
+++ b/src/shared/navigation/core/init.rs
@@ -46,6 +46,7 @@ impl AppModel {
             favorites: Favorites::new(flags.store.clone()),
             favorites_entity: widget::segmented_button::Entity::default(),
             sent_reminders: std::collections::HashSet::new(),
+            toasts: widget::Toasts::new(Message::CloseToast),
         };
 
         let mut tasks = vec![

--- a/src/shared/navigation/core/message.rs
+++ b/src/shared/navigation/core/message.rs
@@ -31,4 +31,5 @@ pub enum Message {
     Trash(trash::Message),
     Favorites(favorites::Message),
     Reminder(ReminderMessage),
+    CloseToast(cosmic::widget::ToastId),
 }

--- a/src/shared/navigation/core/model.rs
+++ b/src/shared/navigation/core/model.rs
@@ -37,4 +37,5 @@ pub struct AppModel {
     pub(crate) favorites: Favorites,
     pub(crate) favorites_entity: nav_bar::Id,
     pub(crate) sent_reminders: HashSet<(Uuid, i64)>,
+    pub(crate) toasts: cosmic::widget::Toasts<super::message::Message>,
 }

--- a/src/shared/navigation/nav/actions.rs
+++ b/src/shared/navigation/nav/actions.rs
@@ -6,6 +6,8 @@ pub enum TasksAction {
     PopulateLists(Vec<List>),
     AddList(List),
     DeleteList(Option<segmented_button::Entity>),
+    RestoreList(uuid::Uuid),
+    RestoreTaskFromList(uuid::Uuid, uuid::Uuid),
     FetchLists,
     NavSelect(segmented_button::Entity),
 }

--- a/src/shared/navigation/nav/update.rs
+++ b/src/shared/navigation/nav/update.rs
@@ -66,17 +66,66 @@ impl AppModel {
                 };
 
                 if let Some(list) = self.nav.data::<List>(entity) {
-                    if let Err(err) = self.store.lists().delete(list.id) {
-                        tracing::error!("Error deleting list: {err}");
+                    let list_id = list.id;
+                    let title = list.name.clone();
+                    if let Err(err) = self.store.trash().trash_list(list_id) {
+                        tracing::error!("Error moving list to trash: {err}");
                     }
 
                     self.nav.remove(entity);
 
-                    return cosmic::task::message(Message::Content(content::Message::SetList(
-                        None,
-                    )));
+                    let mut tasks = vec![
+                        cosmic::task::message(Message::Content(content::Message::SetList(None))),
+                        cosmic::task::message(Message::Trash(
+                            crate::features::trash::trash::Message::Load,
+                        )),
+                        self.toasts
+                            .push(
+                                cosmic::widget::Toast::new(crate::fl!(
+                                    "list-moved-to-trash",
+                                    title = title.as_str()
+                                ))
+                                .action(crate::fl!("undo"), move |_id| {
+                                    Message::Tasks(TasksAction::RestoreList(list_id))
+                                }),
+                            )
+                            .map(cosmic::Action::App),
+                    ];
+                    return app::Task::batch(std::mem::take(&mut tasks));
                 }
                 self.nav.remove(self.nav.active());
+            }
+            TasksAction::RestoreList(list_id) => match self.store.trash().restore_list(list_id) {
+                Ok(list) => {
+                    self.create_nav_item(&list);
+                    self.reposition_special_items();
+                    return cosmic::task::message(Message::Trash(
+                        crate::features::trash::trash::Message::Load,
+                    ));
+                }
+                Err(err) => {
+                    tracing::error!("Error restoring list from trash: {err}");
+                }
+            },
+            TasksAction::RestoreTaskFromList(list_id, task_id) => {
+                match self.store.trash().restore_task_from_list(list_id, task_id) {
+                    Ok(list) => {
+                        let exists = self
+                            .nav
+                            .iter()
+                            .any(|e| self.nav.data::<List>(e).is_some_and(|l| l.id == list.id));
+                        if !exists {
+                            self.create_nav_item(&list);
+                            self.reposition_special_items();
+                        }
+                        return cosmic::task::message(Message::Trash(
+                            crate::features::trash::trash::Message::Load,
+                        ));
+                    }
+                    Err(err) => {
+                        tracing::error!("Error restoring task from trashed list: {err}");
+                    }
+                }
             }
         }
 

--- a/src/shared/store/store.rs
+++ b/src/shared/store/store.rs
@@ -1,4 +1,4 @@
-use crate::features::lists::list::List;
+use crate::features::lists::list::{List, TrashedList};
 use crate::features::tasks::state::{default_states, TaskState};
 use crate::features::tasks::task::{Task, TrashedTask};
 use crate::StoreError;
@@ -11,6 +11,8 @@ use uuid::Uuid;
 const LISTS_REGISTRY: &str = "lists.ron";
 const STATES_REGISTRY: &str = "states.ron";
 const TRASH_DIR: &str = "_trash";
+const TRASHED_LISTS_REGISTRY: &str = "lists.ron";
+const TRASHED_LISTS_DIR: &str = "lists";
 
 fn pretty() -> PrettyConfig {
     PrettyConfig::new().depth_limit(6).struct_names(true)
@@ -63,6 +65,18 @@ impl Store {
         self.trash_dir().join(format!("{task_id}.ron"))
     }
 
+    fn trashed_lists_dir(&self) -> PathBuf {
+        self.trash_dir().join(TRASHED_LISTS_DIR)
+    }
+
+    fn trashed_lists_registry_path(&self) -> PathBuf {
+        self.trashed_lists_dir().join(TRASHED_LISTS_REGISTRY)
+    }
+
+    fn trashed_list_data_dir(&self, list_id: Uuid) -> PathBuf {
+        self.trashed_lists_dir().join(list_id.to_string())
+    }
+
     fn list_dir(&self, list_id: Uuid) -> PathBuf {
         self.base_dir.join(list_id.to_string())
     }
@@ -111,6 +125,155 @@ impl TrashStore<'_> {
         let path = self.store.trashed_task_path(task_id);
         fs::remove_file(&path)
             .map_err(|_| crate::Error::Store(crate::StoreError::TaskNotFound(task_id)))
+    }
+
+    pub fn trash_list(&self, list_id: Uuid) -> crate::Result<()> {
+        let list = self.store.lists().detach(list_id)?;
+
+        fs::create_dir_all(self.store.trashed_lists_dir())?;
+        let list_dir = self.store.list_dir(list_id);
+        if list_dir.exists() {
+            fs::rename(&list_dir, self.store.trashed_list_data_dir(list_id))?;
+        }
+
+        let mut lists = self.load_all_lists()?;
+        lists.retain(|t| t.list.id != list_id);
+        lists.push(TrashedList::new(list));
+        self.flush_lists_registry(&lists)
+    }
+
+    pub fn load_all_lists(&self) -> crate::Result<Vec<TrashedList>> {
+        let path = self.store.trashed_lists_registry_path();
+        if !path.exists() {
+            return Ok(vec![]);
+        }
+        let content = fs::read_to_string(&path)?;
+        Ok(ron::from_str(&content)?)
+    }
+
+    pub fn restore_list(&self, list_id: Uuid) -> crate::Result<List> {
+        let mut lists = self.load_all_lists()?;
+        let pos = lists
+            .iter()
+            .position(|t| t.list.id == list_id)
+            .ok_or(Error::Store(StoreError::ListNotFound(list_id)))?;
+        let trashed = lists.remove(pos);
+
+        let data_dir = self.store.trashed_list_data_dir(list_id);
+        let list_dir = self.store.list_dir(list_id);
+        if data_dir.exists() {
+            fs::rename(&data_dir, &list_dir)?;
+        } else {
+            fs::create_dir_all(&list_dir)?;
+        }
+
+        self.store.lists().save(&trashed.list)?;
+        self.flush_lists_registry(&lists)?;
+        Ok(trashed.list)
+    }
+
+    pub fn delete_list(&self, list_id: Uuid) -> crate::Result<()> {
+        let mut lists = self.load_all_lists()?;
+        let before = lists.len();
+        lists.retain(|t| t.list.id != list_id);
+
+        if lists.len() == before {
+            return Err(Error::Store(StoreError::ListNotFound(list_id)));
+        }
+
+        let data_dir = self.store.trashed_list_data_dir(list_id);
+        if data_dir.exists() {
+            fs::remove_dir_all(&data_dir)?;
+        }
+
+        self.flush_lists_registry(&lists)
+    }
+
+    fn flush_lists_registry(&self, lists: &[TrashedList]) -> crate::Result<()> {
+        fs::create_dir_all(self.store.trashed_lists_dir())?;
+        let content = ron::ser::to_string_pretty(lists, pretty())?;
+        fs::write(self.store.trashed_lists_registry_path(), content)?;
+        Ok(())
+    }
+
+    pub fn load_trashed_list_tasks(&self, list_id: Uuid) -> crate::Result<Vec<Task>> {
+        let data_dir = self.store.trashed_list_data_dir(list_id);
+        if !data_dir.exists() {
+            return Ok(vec![]);
+        }
+
+        let mut tasks = Vec::new();
+        for entry in fs::read_dir(&data_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("ron") {
+                continue;
+            }
+            match fs::read_to_string(&path).map(|s| ron::from_str::<Task>(&s)) {
+                Ok(Ok(task)) => tasks.push(task),
+                Ok(Err(e)) => tracing::error!("skipping {:?}: {e}", path.file_name()),
+                Err(e) => tracing::error!("could not read {:?}: {e}", path.file_name()),
+            }
+        }
+        tasks.sort_by(|a, b| a.creation_date.cmp(&b.creation_date));
+        Ok(tasks)
+    }
+
+    pub fn restore_task_from_list(&self, list_id: Uuid, task_id: Uuid) -> crate::Result<List> {
+        let mut lists = self.load_all_lists()?;
+        let pos = lists
+            .iter()
+            .position(|t| t.list.id == list_id)
+            .ok_or(Error::Store(StoreError::ListNotFound(list_id)))?;
+        let list = lists[pos].list.clone();
+
+        self.store.lists().save(&list)?;
+        let list_dir = self.store.list_dir(list_id);
+        fs::create_dir_all(&list_dir)?;
+
+        let data_dir = self.store.trashed_list_data_dir(list_id);
+        let src = data_dir.join(format!("{task_id}.ron"));
+        let dest = self.store.task_path(list_id, task_id);
+        fs::rename(&src, &dest)
+            .map_err(|_| crate::Error::Store(crate::StoreError::TaskNotFound(task_id)))?;
+
+        if !Self::dir_has_ron_files(&data_dir) {
+            if data_dir.exists() {
+                fs::remove_dir_all(&data_dir)?;
+            }
+            lists.remove(pos);
+            self.flush_lists_registry(&lists)?;
+        }
+
+        Ok(list)
+    }
+
+    pub fn delete_task_from_list(&self, list_id: Uuid, task_id: Uuid) -> crate::Result<()> {
+        let data_dir = self.store.trashed_list_data_dir(list_id);
+        let path = data_dir.join(format!("{task_id}.ron"));
+        fs::remove_file(&path)
+            .map_err(|_| crate::Error::Store(crate::StoreError::TaskNotFound(task_id)))?;
+
+        if !Self::dir_has_ron_files(&data_dir) {
+            if data_dir.exists() {
+                fs::remove_dir_all(&data_dir)?;
+            }
+            let mut lists = self.load_all_lists()?;
+            lists.retain(|t| t.list.id != list_id);
+            self.flush_lists_registry(&lists)?;
+        }
+
+        Ok(())
+    }
+
+    fn dir_has_ron_files(dir: &Path) -> bool {
+        fs::read_dir(dir)
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .any(|e| e.path().extension().and_then(|x| x.to_str()) == Some("ron"))
+            })
+            .unwrap_or(false)
     }
 }
 
@@ -164,21 +327,18 @@ impl ListStore<'_> {
         Ok(updated)
     }
 
-    pub fn delete(&self, list_id: Uuid) -> Result<()> {
-        let list_dir = self.store.list_dir(list_id);
-        if list_dir.exists() {
-            fs::remove_dir_all(&list_dir)?;
-        }
-
+    /// Removes a list from the registry without touching its task directory.
+    /// Used when moving a list to trash, where the directory is relocated
+    /// rather than deleted.
+    pub fn detach(&self, list_id: Uuid) -> Result<List> {
         let mut lists = self.load_all()?;
-        let before = lists.len();
-        lists.retain(|l| l.id != list_id);
-
-        if lists.len() == before {
-            return Err(Error::Store(StoreError::ListNotFound(list_id)));
-        }
-
-        self.flush_registry(&lists)
+        let pos = lists
+            .iter()
+            .position(|l| l.id == list_id)
+            .ok_or(Error::Store(StoreError::ListNotFound(list_id)))?;
+        let list = lists.remove(pos);
+        self.flush_registry(&lists)?;
+        Ok(list)
     }
 
     fn flush_registry(&self, lists: &[List]) -> Result<()> {


### PR DESCRIPTION
Deleting a task or list now moves it to trash and surfaces an "Undo" toast (via libcosmic's toaster) instead of vanishing silently, and permanent deletions (single task, single trashed-list task, whole list, empty trash) now require an explicit confirmation dialog.

Lists can now be trashed and restored like tasks: deleting a list relocates its task directory into trash instead of deleting it outright, and the Trash view groups items by originating list (collapsible sections, mirroring the task view) with a "Restore list" action on fully-trashed lists. Restoring a single task out of a trashed list reactivates the list with just that task, and the whole-list actions disappear from the header once that happens.

Closes #125