### PR TITLE
fix(ui): address UX polish items from issue #117

### DIFF
--- a/i18n/en/tasks.ftl
+++ b/i18n/en/tasks.ftl
@@ -21,6 +21,7 @@ about = About
 # Content
 add-new-task = Add new task
 search-tasks = Search tasks
+search-list = Search { $list }
 
 # Details
 title = Title

--- a/src/app.rs
+++ b/src/app.rs
@@ -307,11 +307,6 @@ impl Application for AppModel {
                             }
                             return app::Task::batch(tasks);
                         }
-                        content::Output::ToggleHideCompleted(list) => {
-                            if let Some(data) = self.nav.active_data_mut::<List>() {
-                                data.hide_completed = list.hide_completed;
-                            }
-                        }
                     }
                 }
             }

--- a/src/features/lists/content.rs
+++ b/src/features/lists/content.rs
@@ -110,8 +110,6 @@ pub enum Message {
     TaskTitleSubmit(DefaultKey),
     TaskTitleUpdate(DefaultKey, String),
 
-    ToggleHideCompleted,
-
     SetList(Option<List>),
     SetTasks(Vec<Task>),
     SyncTasks(Vec<Task>),
@@ -135,7 +133,6 @@ pub enum Message {
 }
 
 pub enum Output {
-    ToggleHideCompleted(List),
     Focus(widget::Id),
     OpenTaskDetails(DefaultKey, Uuid),
     TaskDeleted {
@@ -494,21 +491,6 @@ impl Content {
                     }
                 }
             }
-            Message::ToggleHideCompleted => {
-                if let Some(ref mut selected_list) = self.selected_list {
-                    match self.store.lists().update(selected_list.id, |list| {
-                        list.hide_completed = !selected_list.hide_completed;
-                    }) {
-                        Ok(updated) => {
-                            selected_list.hide_completed = updated.hide_completed;
-                            output = Some(Output::ToggleHideCompleted(updated.clone()));
-                        }
-                        Err(err) => {
-                            tracing::error!("Error updating list: {err}");
-                        }
-                    }
-                }
-            }
             Message::SetSort(sort_by) => {
                 self.config.sort_by = sort_by;
             }
@@ -640,7 +622,7 @@ impl Content {
         let sorted_tasks = self.sort_tasks();
         let visible_tasks: Vec<_> = sorted_tasks
             .into_iter()
-            .filter(|(_, task)| self.should_show_task(list, task))
+            .filter(|(_, task)| self.should_show_task(task))
             .collect();
 
         if visible_tasks.is_empty() && self.search_query.is_empty() {
@@ -662,50 +644,31 @@ impl Content {
         let spacing = theme::active().cosmic().spacing;
 
         let title = widget::text::title4(&list.name).width(Length::Fill);
-        let hide_completed_button = self.create_hide_completed_button(list, &spacing);
         let search_button = self.create_search_button(&spacing);
         let list_icon = self.create_list_icon(list, &spacing);
 
-        widget::row::with_capacity(4)
+        widget::row::with_capacity(3)
             .align_y(Alignment::Center)
             .spacing(spacing.space_s)
             .padding([spacing.space_none, spacing.space_xxs])
             .push(list_icon)
             .push(title)
-            .push(hide_completed_button)
             .push(search_button)
             .into()
     }
 
     fn create_search_input<'a>(&'a self, spacing: &Spacing) -> Element<'a, Message> {
-        widget::text_input(fl!("search-tasks"), &self.search_query)
+        let placeholder = match &self.selected_list {
+            Some(list) => fl!("search-list", list = list.name.as_str()),
+            None => fl!("search-tasks"),
+        };
+
+        widget::text_input(placeholder, &self.search_query)
             .id(widget::Id::new("search-tasks-input"))
             .on_input(Message::SearchQueryChanged)
             .width(Length::Fill)
             .padding([spacing.space_xxs, spacing.space_xxs])
             .into()
-    }
-
-    fn create_hide_completed_button<'a>(
-        &'a self,
-        list: &'a List,
-        spacing: &Spacing,
-    ) -> Element<'a, Message> {
-        let is_active = list.hide_completed || self.config.hide_completed;
-        let mut button =
-            widget::button::icon(widget::icon::from_name("checkbox-checked-symbolic").size(18))
-                .selected(is_active)
-                .padding(spacing.space_xxs);
-
-        if is_active {
-            button = button.class(cosmic::style::Button::Suggested);
-        }
-
-        if !self.config.hide_completed {
-            button = button.on_press(Message::ToggleHideCompleted);
-        }
-
-        button.into()
     }
 
     fn create_search_button<'a>(&'a self, spacing: &Spacing) -> Element<'a, Message> {
@@ -793,7 +756,7 @@ impl Content {
         collapsible_section::section(header, rows, collapsed)
     }
 
-    fn should_show_task(&self, list: &List, task: &Task) -> bool {
+    fn should_show_task(&self, task: &Task) -> bool {
         let is_top_level = task.parent_id.is_none();
 
         let matches_search = !self.search_bar_visible
@@ -803,8 +766,7 @@ impl Content {
                 .to_lowercase()
                 .contains(&self.search_query.to_lowercase());
 
-        let should_hide_completed = list.hide_completed || self.config.hide_completed;
-        let show_despite_completion = !should_hide_completed || !task.is_completed();
+        let show_despite_completion = !self.config.hide_completed || !task.is_completed();
 
         is_top_level && matches_search && show_despite_completion
     }
@@ -812,7 +774,7 @@ impl Content {
     pub fn task_view<'a>(&'a self, id: DefaultKey, task: &'a Task) -> Element<'a, Message> {
         let spacing = theme::active().cosmic().spacing;
 
-        let sub_tasks = self.get_subtasks(task, self.selected_list.as_ref());
+        let sub_tasks = self.get_subtasks(task);
         let task_row = self.create_task_row(id, task, &sub_tasks, &spacing);
 
         let mut column = widget::column::with_capacity(2).push(task_row);
@@ -856,10 +818,8 @@ impl Content {
         .into()
     }
 
-    fn get_subtasks(&self, task: &Task, list: Option<&List>) -> Vec<(DefaultKey, &Task)> {
-        let should_hide_completed = list
-            .map(|l| l.hide_completed || self.config.hide_completed)
-            .unwrap_or(false);
+    fn get_subtasks(&self, task: &Task) -> Vec<(DefaultKey, &Task)> {
+        let should_hide_completed = self.config.hide_completed;
 
         self.tasks
             .iter()

--- a/src/features/tasks/details.rs
+++ b/src/features/tasks/details.rs
@@ -244,7 +244,6 @@ impl Details {
                 }))
                 .into(),
             widget::button::destructive(fl!("delete"))
-                .trailing_icon(widget::icon::from_name("edit-delete-symbolic").size(14))
                 .on_press(Message::Delete)
                 .into(),
         ])

--- a/src/shared/navigation/core/init.rs
+++ b/src/shared/navigation/core/init.rs
@@ -108,11 +108,17 @@ pub fn key_binds() -> HashMap<KeyBind, MenuAction> {
     bind!([Ctrl], Key::Character("n".into()), NewList);
     bind!([Ctrl], Key::Named(Named::Delete), DeleteList);
     bind!([Ctrl], Key::Character("r".into()), RenameList);
-    bind!([Ctrl], Key::Character("I".into()), Icon);
+    bind!([Ctrl, Shift], Key::Character("i".into()), Icon);
     bind!([Ctrl], Key::Character("w".into()), WindowClose);
     bind!([Ctrl, Shift], Key::Character("n".into()), WindowNew);
     bind!([Ctrl], Key::Character(",".into()), Settings);
     bind!([Ctrl], Key::Character("i".into()), About);
+    bind!([Ctrl], Key::Character("f".into()), ToggleSearchBar);
+    bind!(
+        [Ctrl],
+        Key::Character("h".into()),
+        ToggleHideCompletedShortcut
+    );
 
     key_binds
 }

--- a/src/shared/navigation/ui/actions.rs
+++ b/src/shared/navigation/ui/actions.rs
@@ -4,6 +4,7 @@ use cosmic::{
 };
 
 use crate::app::{ContextPage, Message};
+use crate::features::lists::content;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MenuAction {
@@ -16,6 +17,8 @@ pub enum MenuAction {
     RenameList,
     Icon,
     ToggleHideCompleted(bool),
+    ToggleHideCompletedShortcut,
+    ToggleSearchBar,
     SortByNameAsc,
     SortByNameDesc,
     SortByDateAsc,
@@ -39,6 +42,7 @@ impl Action for MenuAction {
         match self {
             MenuAction::About => Message::ToggleContextPage(ContextPage::About),
             MenuAction::Settings => Message::ToggleContextPage(ContextPage::Settings),
+            MenuAction::ToggleSearchBar => Message::Content(content::Message::ToggleSearchBar),
             action => Message::Menu(*action),
         }
     }

--- a/src/shared/navigation/ui/menu.rs
+++ b/src/shared/navigation/ui/menu.rs
@@ -123,6 +123,13 @@ pub fn menu_bar<'a>(state: &AppModel) -> Element<'a, Message> {
             items(
                 &state.key_binds,
                 vec![
+                    Item::CheckBox(
+                        fl!("hide-completed"),
+                        None,
+                        state.config.hide_completed,
+                        MenuAction::ToggleHideCompleted(!state.config.hide_completed),
+                    ),
+                    Item::Divider,
                     Item::Button(
                         fl!("menu-settings"),
                         Some(

--- a/src/shared/navigation/ui/update.rs
+++ b/src/shared/navigation/ui/update.rs
@@ -141,6 +141,16 @@ impl AppModel {
                     self.config.clone(),
                 )));
             }
+            MenuAction::ToggleHideCompletedShortcut => {
+                let completed = !self.config.hide_completed;
+                if let Err(err) = self.config.set_hide_completed(&self.handler, completed) {
+                    tracing::error!("{err}")
+                }
+                return cosmic::task::message(Message::Content(content::Message::SetConfig(
+                    self.config.clone(),
+                )));
+            }
+            MenuAction::ToggleSearchBar => {}
             MenuAction::SortByNameAsc => {
                 if let Err(err) = self
                     .config

--- a/src/shared/widgets/style/text_editor.rs
+++ b/src/shared/widgets/style/text_editor.rs
@@ -9,8 +9,8 @@ fn style(
     let cosmic = theme.cosmic();
     let container = theme.current_container();
 
-    let mut background: cosmic::iced::Color = cosmic.palette.neutral_2.into();
-    background.a = 0.50;
+    let mut background: cosmic::iced::Color = container.small_widget.into();
+    background.a = 0.25;
 
     let selection = cosmic.accent.base.into();
     let value = cosmic.palette.neutral_9.into();
@@ -25,7 +25,7 @@ fn style(
                 background: background.into(),
                 border: cosmic::iced::Border {
                     radius: cosmic.corner_radii.radius_s.into(),
-                    width: 1.0,
+                    width: 2.0,
                     color: container.component.divider.into(),
                 },
                 placeholder,
@@ -33,13 +33,25 @@ fn style(
                 selection,
             }
         }
-        cosmic::iced::widget::text_editor::Status::Hovered
-        | cosmic::iced::widget::text_editor::Status::Focused { .. } => {
+        cosmic::iced::widget::text_editor::Status::Hovered => {
             cosmic::iced::widget::text_editor::Style {
                 background: background.into(),
                 border: cosmic::iced::Border {
                     radius: cosmic.corner_radii.radius_s.into(),
-                    width: 1.0,
+                    width: 2.0,
+                    color: cosmic::iced::Color::from(cosmic.accent.base),
+                },
+                placeholder,
+                value,
+                selection,
+            }
+        }
+        cosmic::iced::widget::text_editor::Status::Focused { .. } => {
+            cosmic::iced::widget::text_editor::Style {
+                background: background.into(),
+                border: cosmic::iced::Border {
+                    radius: cosmic.corner_radii.radius_s.into(),
+                    width: 3.0,
                     color: cosmic::iced::Color::from(cosmic.accent.base),
                 },
                 placeholder,


### PR DESCRIPTION
This PR brings several UX improvements, thanks @KodeBarista!

- Search field placeholder is now context-aware ("Search <list>") instead of the generic "Search tasks"
- Delete button in the task edit pane is text-only, no redundant icon
- Fix Ctrl+I: "Set icon" and "About" silently collided on the same key event, so "Set icon" never fired; rebind it to Ctrl+Shift+I
- Add Ctrl+F (toggle search) and Ctrl+H (toggle hide-completed) shortcuts
- "Hide completed" is now a single global toggle in the View menu instead of a confusing, easy-to-miss per-list checkbox
- Notes editor border now matches text_input's active/hover/focus treatment instead of using the same thin border for every state, and its background alpha matches text_input's instead of being noticeably darker

Closes #117