### PR TITLE
feat: global search

### DIFF
--- a/i18n/en/tasks.ftl
+++ b/i18n/en/tasks.ftl
@@ -23,6 +23,12 @@ add-new-task = Add new task
 search-tasks = Search tasks
 search-list = Search { $list }
 
+# Search
+search-all-tasks = Search all tasks
+search-results = Search results ({ $count })
+no-search-results = No results
+no-search-results-suggestion = Try a different search term
+
 # Details
 title = Title
 details = Details

--- a/src/app.rs
+++ b/src/app.rs
@@ -77,6 +77,10 @@ impl Application for AppModel {
         vec![ui::menu::menu_bar(&self)]
     }
 
+    fn header_end(&self) -> Vec<Element<'_, Self::Message>> {
+        vec![self.search.header_view().map(Message::Search)]
+    }
+
     fn nav_context_menu(&self) -> Option<Vec<widget::menu::Tree<cosmic::Action<Self::Message>>>> {
         let items = self.nav.iter().map(|entity| {
             let favorites_index_opt = self.nav.data::<FavoritesMarker>(entity);
@@ -469,6 +473,50 @@ impl Application for AppModel {
                     }
                 }
             }
+            Message::Search(msg) => {
+                if let Some(output) = self.search.update(msg) {
+                    match output {
+                        crate::features::search::search::Output::OpenTask { task, list_id } => {
+                            let entity = self.nav.iter().find(|e| {
+                                self.nav.data::<List>(*e).is_some_and(|l| l.id == list_id)
+                            });
+                            let Some(entity) = entity else {
+                                tracing::error!("Nav entity not found for list {list_id}");
+                                return app::Task::none();
+                            };
+                            self.nav.activate(entity);
+
+                            let mut tasks = vec![
+                                cosmic::task::message(Message::Search(
+                                    crate::features::search::search::Message::QueryChanged(
+                                        String::new(),
+                                    ),
+                                )),
+                                cosmic::task::message(Message::ToggleContextPage(
+                                    ContextPage::TaskDetails,
+                                )),
+                            ];
+
+                            if let Some(list) = self.nav.data::<List>(entity) {
+                                tasks.push(self.update(Message::Content(
+                                    content::Message::SetList(Some(list.clone())),
+                                )));
+                            }
+
+                            let Some(key) = self.content.find_task_key(task.id) else {
+                                tracing::error!("Task key not found after loading list");
+                                return app::Task::none();
+                            };
+
+                            tasks.push(cosmic::task::message(Message::Details(
+                                details::Message::SetTask(key, task, list_id),
+                            )));
+
+                            return app::Task::batch(tasks);
+                        }
+                    }
+                }
+            }
             Message::Tasks(action) => {
                 return self.update_tasks(action);
             }
@@ -501,7 +549,9 @@ impl Application for AppModel {
     }
 
     fn view(&self) -> Element<'_, Self::Message> {
-        let content = if self.nav.active_data::<TrashMarker>().is_some() {
+        let content = if self.search.has_query() {
+            self.search.view().map(Message::Search)
+        } else if self.nav.active_data::<TrashMarker>().is_some() {
             self.trash.view().map(Message::Trash)
         } else if self.nav.active_data::<FavoritesMarker>().is_some() {
             self.favorites.view().map(Message::Favorites)

--- a/src/app.rs
+++ b/src/app.rs
@@ -556,7 +556,9 @@ impl Application for AppModel {
         } else if self.nav.active_data::<FavoritesMarker>().is_some() {
             self.favorites.view().map(Message::Favorites)
         } else {
-            self.content.view().map(Message::Content)
+            self.content
+                .view(self.core.is_condensed())
+                .map(Message::Content)
         };
 
         widget::toaster(&self.toasts, content)

--- a/src/features/lists/content.rs
+++ b/src/features/lists/content.rs
@@ -615,10 +615,6 @@ impl Content {
         let mut column = widget::column::with_capacity(3);
         column = column.push(self.list_header(list));
 
-        if self.search_bar_visible {
-            column = column.push(self.create_search_input(&spacing));
-        }
-
         let sorted_tasks = self.sort_tasks();
         let visible_tasks: Vec<_> = sorted_tasks
             .into_iter()
@@ -643,36 +639,53 @@ impl Content {
     fn list_header<'a>(&'a self, list: &'a List) -> Element<'a, Message> {
         let spacing = theme::active().cosmic().spacing;
 
-        let title = widget::text::title4(&list.name).width(Length::Fill);
-        let search_button = self.create_search_button(&spacing);
         let list_icon = self.create_list_icon(list, &spacing);
+        let search_button = self.create_search_button(&spacing);
 
-        widget::row::with_capacity(3)
+        let title_width = if self.search_bar_visible {
+            Length::Shrink
+        } else {
+            Length::Fill
+        };
+        let title = widget::text::title4(&list.name).width(title_width);
+
+        let mut row = widget::row::with_capacity(4)
             .align_y(Alignment::Center)
             .spacing(spacing.space_s)
             .padding([spacing.space_none, spacing.space_xxs])
             .push(list_icon)
-            .push(title)
-            .push(search_button)
-            .into()
+            .push(title);
+
+        if self.search_bar_visible {
+            row = row.push(widget::space::horizontal());
+            row = row.push(self.create_search_input(&spacing));
+        }
+
+        row.push(search_button).into()
     }
 
-    fn create_search_input<'a>(&'a self, spacing: &Spacing) -> Element<'a, Message> {
+    fn create_search_input<'a>(&'a self, _spacing: &Spacing) -> Element<'a, Message> {
         let placeholder = match &self.selected_list {
             Some(list) => fl!("search-list", list = list.name.as_str()),
             None => fl!("search-tasks"),
         };
 
-        widget::text_input(placeholder, &self.search_query)
+        widget::search_input(placeholder, &self.search_query)
             .id(widget::Id::new("search-tasks-input"))
             .on_input(Message::SearchQueryChanged)
-            .width(Length::Fill)
-            .padding([spacing.space_xxs, spacing.space_xxs])
+            .on_clear(Message::SearchQueryChanged(String::new()))
+            .width(Length::Fixed(240.0))
             .into()
     }
 
     fn create_search_button<'a>(&'a self, spacing: &Spacing) -> Element<'a, Message> {
-        widget::button::icon(widget::icon::from_name("edit-find-symbolic").size(18))
+        let icon_name = if self.search_bar_visible {
+            "window-close-symbolic"
+        } else {
+            "edit-find-symbolic"
+        };
+
+        widget::button::icon(widget::icon::from_name(icon_name).size(18))
             .selected(self.search_bar_visible)
             .padding(spacing.space_xxs)
             .on_press(Message::ToggleSearchBar)

--- a/src/features/lists/content.rs
+++ b/src/features/lists/content.rs
@@ -162,14 +162,14 @@ impl MenuAction for TaskAction {
 }
 
 impl Content {
-    pub fn view(&self) -> Element<'_, Message> {
+    pub fn view(&self, is_condensed: bool) -> Element<'_, Message> {
         let spacing = theme::active().cosmic().spacing;
 
         let Some(ref list) = self.selected_list else {
             return self.create_no_list_selected_view();
         };
 
-        let mut column = widget::column(vec![self.list_view(list)]);
+        let mut column = widget::column(vec![self.list_view(list, is_condensed)]);
 
         column = column.push(self.new_task_view());
 
@@ -609,11 +609,15 @@ impl Content {
         }
     }
 
-    pub fn list_view<'a>(&'a self, list: &'a List) -> Element<'a, Message> {
+    pub fn list_view<'a>(&'a self, list: &'a List, is_condensed: bool) -> Element<'a, Message> {
         let spacing = theme::active().cosmic().spacing;
 
         let mut column = widget::column::with_capacity(3);
-        column = column.push(self.list_header(list));
+        column = column.push(self.list_header(list, is_condensed));
+
+        if is_condensed && self.search_bar_visible {
+            column = column.push(self.create_search_input(&spacing, is_condensed));
+        }
 
         let sorted_tasks = self.sort_tasks();
         let visible_tasks: Vec<_> = sorted_tasks
@@ -622,7 +626,7 @@ impl Content {
             .collect();
 
         if visible_tasks.is_empty() && self.search_query.is_empty() {
-            return self.empty(list);
+            return self.empty(list, is_condensed);
         }
 
         let sections = self.section_views(visible_tasks);
@@ -636,13 +640,15 @@ impl Content {
         .into()
     }
 
-    fn list_header<'a>(&'a self, list: &'a List) -> Element<'a, Message> {
+    fn list_header<'a>(&'a self, list: &'a List, is_condensed: bool) -> Element<'a, Message> {
         let spacing = theme::active().cosmic().spacing;
 
         let list_icon = self.create_list_icon(list, &spacing);
         let search_button = self.create_search_button(&spacing);
 
-        let title_width = if self.search_bar_visible {
+        let inline_search = self.search_bar_visible && !is_condensed;
+
+        let title_width = if inline_search {
             Length::Shrink
         } else {
             Length::Fill
@@ -656,25 +662,35 @@ impl Content {
             .push(list_icon)
             .push(title);
 
-        if self.search_bar_visible {
+        if inline_search {
             row = row.push(widget::space::horizontal());
-            row = row.push(self.create_search_input(&spacing));
+            row = row.push(self.create_search_input(&spacing, is_condensed));
         }
 
         row.push(search_button).into()
     }
 
-    fn create_search_input<'a>(&'a self, _spacing: &Spacing) -> Element<'a, Message> {
+    fn create_search_input<'a>(
+        &'a self,
+        _spacing: &Spacing,
+        is_condensed: bool,
+    ) -> Element<'a, Message> {
         let placeholder = match &self.selected_list {
             Some(list) => fl!("search-list", list = list.name.as_str()),
             None => fl!("search-tasks"),
+        };
+
+        let width = if is_condensed {
+            Length::Fill
+        } else {
+            Length::Fixed(240.0)
         };
 
         widget::search_input(placeholder, &self.search_query)
             .id(widget::Id::new("search-tasks-input"))
             .on_input(Message::SearchQueryChanged)
             .on_clear(Message::SearchQueryChanged(String::new()))
-            .width(Length::Fixed(240.0))
+            .width(width)
             .into()
     }
 
@@ -1014,13 +1030,13 @@ impl Content {
         widget::column::with_children(subtask_elements).into()
     }
 
-    pub fn empty<'a>(&'a self, list: &'a List) -> Element<'a, Message> {
+    pub fn empty<'a>(&'a self, list: &'a List, is_condensed: bool) -> Element<'a, Message> {
         let spacing = theme::active().cosmic().spacing;
 
         let empty_state = self.create_empty_state_content();
 
         widget::column::with_capacity(2)
-            .push(self.list_header(list))
+            .push(self.list_header(list, is_condensed))
             .push(empty_state)
             .padding([spacing.space_none, spacing.space_l])
             .spacing(spacing.space_s)

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -1,6 +1,7 @@
 pub mod favorites;
 pub mod lists;
 pub mod reminders;
+pub mod search;
 pub mod settings;
 pub mod tasks;
 pub mod trash;

--- a/src/features/search/mod.rs
+++ b/src/features/search/mod.rs
@@ -1,0 +1,1 @@
+pub mod search;

--- a/src/features/search/search.rs
+++ b/src/features/search/search.rs
@@ -1,0 +1,264 @@
+use std::collections::HashSet;
+
+use cosmic::{
+    iced::{
+        alignment::{Horizontal, Vertical},
+        Alignment, Length,
+    },
+    theme, widget, Apply, Element,
+};
+
+use uuid::Uuid;
+
+use crate::{
+    features::{lists::list::List, tasks::task::Task},
+    fl,
+    shared::{store::Store, widgets::collapsible_section},
+};
+
+#[derive(Debug, Clone)]
+pub struct SearchEntry {
+    pub task: Task,
+    pub list_id: Uuid,
+    pub list_name: String,
+}
+
+pub struct Search {
+    query: String,
+    entries: Vec<SearchEntry>,
+    collapsed_sections: HashSet<Uuid>,
+    store: Store,
+}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    QueryChanged(String),
+    Load,
+    Loaded(Vec<SearchEntry>),
+    Open(Uuid),
+    ToggleSection(Uuid),
+}
+
+pub enum Output {
+    OpenTask { task: Task, list_id: Uuid },
+}
+
+impl Search {
+    pub fn new(store: Store) -> Self {
+        Self {
+            query: String::new(),
+            entries: Vec::new(),
+            collapsed_sections: HashSet::new(),
+            store,
+        }
+    }
+
+    pub fn has_query(&self) -> bool {
+        !self.query.trim().is_empty()
+    }
+
+    pub fn update(&mut self, message: Message) -> Option<Output> {
+        match message {
+            Message::QueryChanged(query) => {
+                self.query = query;
+            }
+            Message::Load => {
+                let lists: Vec<List> = self.store.lists().load_all().unwrap_or_else(|e| {
+                    tracing::error!("Failed to load lists for search: {e}");
+                    vec![]
+                });
+
+                let mut entries = Vec::new();
+                for list in &lists {
+                    let tasks = self.store.tasks(list.id).load_all().unwrap_or_else(|e| {
+                        tracing::error!("Failed to load tasks for list {}: {e}", list.id);
+                        vec![]
+                    });
+                    for task in tasks {
+                        entries.push(SearchEntry {
+                            task,
+                            list_id: list.id,
+                            list_name: list.name.clone(),
+                        });
+                    }
+                }
+
+                return self.update(Message::Loaded(entries));
+            }
+            Message::Loaded(entries) => {
+                self.entries = entries;
+            }
+            Message::Open(task_id) => {
+                if let Some(entry) = self.entries.iter().find(|e| e.task.id == task_id) {
+                    return Some(Output::OpenTask {
+                        task: entry.task.clone(),
+                        list_id: entry.list_id,
+                    });
+                }
+            }
+            Message::ToggleSection(list_id) => {
+                if !self.collapsed_sections.remove(&list_id) {
+                    self.collapsed_sections.insert(list_id);
+                }
+            }
+        }
+        None
+    }
+
+    pub fn header_view(&self) -> Element<'_, Message> {
+        widget::search_input(fl!("search-all-tasks"), &self.query)
+            .id(widget::Id::new("global-search-input"))
+            .on_input(Message::QueryChanged)
+            .on_clear(Message::QueryChanged(String::new()))
+            .width(Length::Fixed(240.0))
+            .into()
+    }
+
+    pub fn view(&self) -> Element<'_, Message> {
+        let spacing = theme::active().cosmic().spacing;
+
+        let query = self.query.to_lowercase();
+        let matches: Vec<&SearchEntry> = self
+            .entries
+            .iter()
+            .filter(|e| e.task.title.to_lowercase().contains(&query))
+            .collect();
+
+        if matches.is_empty() {
+            return self.no_results_view();
+        }
+
+        let header = self.header_row(matches.len());
+        let sections = self.list_sections(matches);
+        let list = widget::column::with_children(sections).spacing(spacing.space_xxs);
+
+        let content = widget::column::with_capacity(2)
+            .push(header)
+            .push(widget::scrollable(list).height(Length::Fill))
+            .spacing(spacing.space_s)
+            .padding([spacing.space_xxs, spacing.space_xxxs]);
+
+        widget::container(content)
+            .height(Length::Fill)
+            .width(Length::Fill)
+            .center_x(Length::Fill)
+            .max_width(800.)
+            .apply(widget::container)
+            .height(Length::Fill)
+            .width(Length::Fill)
+            .center(Length::Fill)
+            .into()
+    }
+
+    fn header_row(&self, count: usize) -> Element<'_, Message> {
+        let spacing = theme::active().cosmic().spacing;
+
+        let icon = widget::icon::from_name("edit-find-symbolic").size(spacing.space_m);
+        let title = widget::text::title4(fl!("search-results", count = count)).width(Length::Fill);
+
+        widget::row::with_capacity(2)
+            .align_y(Alignment::Center)
+            .spacing(spacing.space_s)
+            .padding([spacing.space_none, spacing.space_xxs])
+            .push(icon)
+            .push(title)
+            .into()
+    }
+
+    fn list_sections<'a>(&'a self, matches: Vec<&'a SearchEntry>) -> Vec<Element<'a, Message>> {
+        let mut list_ids: Vec<Uuid> = Vec::new();
+        for e in &matches {
+            if !list_ids.contains(&e.list_id) {
+                list_ids.push(e.list_id);
+            }
+        }
+
+        let mut sections: Vec<(String, Element<'_, Message>)> = list_ids
+            .into_iter()
+            .map(|list_id| {
+                let entries: Vec<&SearchEntry> = matches
+                    .iter()
+                    .copied()
+                    .filter(|e| e.list_id == list_id)
+                    .collect();
+                let name = entries
+                    .first()
+                    .map(|e| e.list_name.clone())
+                    .unwrap_or_else(|| fl!("unknown-list"));
+
+                let section = self.list_section(list_id, name.clone(), entries);
+                (name, section)
+            })
+            .collect();
+
+        sections.sort_by(|a, b| a.0.cmp(&b.0));
+        sections.into_iter().map(|(_, section)| section).collect()
+    }
+
+    fn list_section<'a>(
+        &'a self,
+        list_id: Uuid,
+        name: String,
+        entries: Vec<&'a SearchEntry>,
+    ) -> Element<'a, Message> {
+        let spacing = theme::active().cosmic().spacing;
+        let collapsed = self.collapsed_sections.contains(&list_id);
+        let count = entries.len();
+
+        let header = collapsible_section::section_header(
+            name,
+            None,
+            count,
+            collapsed,
+            Vec::new(),
+            Message::ToggleSection(list_id),
+            &spacing,
+        );
+
+        let rows = entries
+            .into_iter()
+            .map(|entry| self.entry_row(entry))
+            .collect();
+
+        collapsible_section::section(header, rows, collapsed)
+    }
+
+    fn entry_row<'a>(&'a self, entry: &'a SearchEntry) -> Element<'a, Message> {
+        let spacing = theme::active().cosmic().spacing;
+
+        let title = widget::text::body(entry.task.title.as_str()).width(Length::Fill);
+
+        let open_button =
+            widget::button::icon(widget::icon::from_name("go-next-symbolic").size(16))
+                .padding(spacing.space_xxs)
+                .on_press(Message::Open(entry.task.id));
+
+        let row = widget::row::with_capacity(2)
+            .align_y(Alignment::Center)
+            .spacing(spacing.space_s)
+            .padding([spacing.space_xxs, spacing.space_xxs])
+            .push(title)
+            .push(open_button);
+
+        collapsible_section::row_item(row.into())
+    }
+
+    fn no_results_view(&self) -> Element<'_, Message> {
+        widget::container(
+            widget::column::with_children(vec![
+                widget::icon::from_name("edit-find-symbolic")
+                    .size(56)
+                    .into(),
+                widget::text::title1(fl!("no-search-results")).into(),
+                widget::text(fl!("no-search-results-suggestion")).into(),
+            ])
+            .spacing(10)
+            .align_x(Alignment::Center),
+        )
+        .align_y(Vertical::Center)
+        .align_x(Horizontal::Center)
+        .height(Length::Fill)
+        .width(Length::Fill)
+        .into()
+    }
+}

--- a/src/shared/navigation/core/init.rs
+++ b/src/shared/navigation/core/init.rs
@@ -12,8 +12,8 @@ use cosmic::{
 
 use crate::{
     features::{
-        favorites::favorites::Favorites, lists::content::Content, tasks::details::Details,
-        trash::trash::Trash,
+        favorites::favorites::Favorites, lists::content::Content, search::search::Search,
+        tasks::details::Details, trash::trash::Trash,
     },
     fl,
     shared::navigation::{nav::TasksAction, ui::MenuAction},
@@ -47,11 +47,15 @@ impl AppModel {
             favorites_entity: widget::segmented_button::Entity::default(),
             sent_reminders: std::collections::HashSet::new(),
             toasts: widget::Toasts::new(Message::CloseToast),
+            search: Search::new(flags.store.clone()),
         };
 
         let mut tasks = vec![
             cosmic::task::message(Message::Tasks(TasksAction::FetchLists)),
             cosmic::task::message(Message::Trash(crate::features::trash::trash::Message::Load)),
+            cosmic::task::message(Message::Search(
+                crate::features::search::search::Message::Load,
+            )),
         ];
 
         if let Some(id) = app.core.main_window_id() {

--- a/src/shared/navigation/core/message.rs
+++ b/src/shared/navigation/core/message.rs
@@ -1,8 +1,8 @@
 use crate::{
     config::AppConfig,
     features::{
-        favorites::favorites, lists::content, reminders::reminder::ReminderMessage, tasks::details,
-        trash::trash,
+        favorites::favorites, lists::content, reminders::reminder::ReminderMessage,
+        search::search, tasks::details, trash::trash,
     },
     shared::{
         dialogs::DialogAction,
@@ -32,4 +32,5 @@ pub enum Message {
     Favorites(favorites::Message),
     Reminder(ReminderMessage),
     CloseToast(cosmic::widget::ToastId),
+    Search(search::Message),
 }

--- a/src/shared/navigation/core/model.rs
+++ b/src/shared/navigation/core/model.rs
@@ -12,8 +12,8 @@ use uuid::Uuid;
 use crate::{
     config,
     features::{
-        favorites::favorites::Favorites, lists::content::Content, tasks::details::Details,
-        trash::trash::Trash,
+        favorites::favorites::Favorites, lists::content::Content, search::search::Search,
+        tasks::details::Details, trash::trash::Trash,
     },
     shared::{dialogs::DialogPage, navigation::ui::MenuAction, store::Store},
 };
@@ -38,4 +38,5 @@ pub struct AppModel {
     pub(crate) favorites_entity: nav_bar::Id,
     pub(crate) sent_reminders: HashSet<(Uuid, i64)>,
     pub(crate) toasts: cosmic::widget::Toasts<super::message::Message>,
+    pub(crate) search: Search,
 }

--- a/src/shared/navigation/nav/update.rs
+++ b/src/shared/navigation/nav/update.rs
@@ -184,9 +184,12 @@ impl AppModel {
         }
         self.reposition_special_items();
 
-        let mut tasks = vec![cosmic::task::message(Message::Trash(
-            crate::features::trash::trash::Message::Load,
-        ))];
+        let mut tasks = vec![
+            cosmic::task::message(Message::Trash(crate::features::trash::trash::Message::Load)),
+            cosmic::task::message(Message::Search(
+                crate::features::search::search::Message::Load,
+            )),
+        ];
 
         if removed_active {
             tasks.push(cosmic::task::message(Message::Content(


### PR DESCRIPTION
This PR adds a global search box that's always present in the window header and searches every list's tasks at once. 

Results are grouped into collapsible sections by originating list, and selecting a result clears the query, activates that task's list, and opens its details pane. Results are loaded at startup and refreshed on every disk-sync pass so multi-window edits stay visible.

<img width="939" height="137" alt="image" src="https://github.com/user-attachments/assets/152ba402-37b1-48e2-a9e4-12dadbe9925e" />

Improves the layout of the search bar in the tasks view, it now uses `widget::search_bar` and it uses `is_condensed` to adjust for smaller width windows.

<img width="695" height="173" alt="image" src="https://github.com/user-attachments/assets/815ad48a-3b52-484e-9d34-118bc1de349f" />

Thanks to @kodebarista for the suggestion.